### PR TITLE
Fix GitHub Actions workflow by removing unsupported telemetry command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,6 @@ jobs:
           if [ ! -d cordova ]; then
             cordova create cordova com.easierbycode.game2019es7 "2019-es7"
             cd cordova
-            cordova telemetry off
             cordova platform add android@latest
           fi
 


### PR DESCRIPTION
- Remove `cordova telemetry off` which is not supported in Cordova 13
- Ensure Cordova build targets Android 15/16 smoothly
- Maintain GitHub Pages deployment with APK available at /game.apk