### PR TITLE
Request fullscreen on canvas when user picks mode select

### DIFF
--- a/src/scenes/LoadScene.js
+++ b/src/scenes/LoadScene.js
@@ -213,6 +213,19 @@ export class LoadScene extends BaseScene {
     }
 
     loadStart(lowModeFlg) {
+        if (typeof document !== "undefined") {
+            const element = document.documentElement;
+            const requestMethod = element.requestFullscreen ||
+                element.webkitRequestFullscreen ||
+                element.msRequestFullscreen;
+
+            if (requestMethod) {
+                requestMethod.call(element).catch((error) => {
+                    log("Fullscreen request failed: " + error.message);
+                });
+            }
+        }
+
         this.lowModeFlg = lowModeFlg;
         this.state.lowModeFlg = lowModeFlg;
 


### PR DESCRIPTION
I have implemented the fullscreen request in `src/scenes/LoadScene.js`. When a user picks a mode (PC or SP), the `loadStart` method is called, which now includes a cross-browser fullscreen request on the root document element. This ensures the game covers the entire screen upon user interaction.

I verified the change using a Playwright script that mocks the fullscreen API and confirms it is called when the mode buttons are clicked. I also performed a visual check with a screenshot to ensure the game continues to load correctly.

---
*PR created automatically by Jules for task [10803943432944796945](https://jules.google.com/task/10803943432944796945) started by @easierbycode*