### PR TITLE
Fix fullscreen/orientation: lock portrait after fullscreen entry, pre…

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,21 @@
         #canvas canvas {
             image-rendering: pixelated;
             image-rendering: crisp-edges;
+            touch-action: none;
+        }
+
+        /* Force portrait layout even when the OS ignores orientation lock */
+        @media screen and (orientation: landscape) {
+            html {
+                transform: rotate(-90deg);
+                transform-origin: left top;
+                width: 100vh;
+                height: 100vw;
+                overflow: hidden;
+                position: absolute;
+                top: 100%;
+                left: 0;
+            }
         }
     </style>
 


### PR DESCRIPTION
…vent edge swipes

The previous approach locked orientation at startup (before fullscreen was active) which most mobile browsers silently ignore. Now:

- Orientation is locked inside the fullscreen success callback where the API actually works
- Edge-swipe touches (within 30px of screen edges) are intercepted and preventDefault'd to stop iOS Safari / Chrome back-gesture
- A fullscreenchange listener auto-re-enters fullscreen if the user exits
- CSS forces portrait layout via transform when the OS ignores the JS lock
- history.pushState traps popstate to prevent browser-back on overscroll
- requestFullscreen uses { navigationUI: "hide" } for cleaner immersion

https://claude.ai/code/session_01NAJUd1xWhNy1EjxguEVKQk