### PR TITLE
Fix Cordova rotation and fullscreen: install plugins in build, lock portrait in manifest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,9 @@ jobs:
             cordova platform add android@latest
           fi
 
+      - name: Copy project config.xml into Cordova project
+        run: cp config.xml cordova/config.xml
+
       - name: Update config.xml for Android 15/16
         run: |
           # Set target-sdk to 35 (Android 15) for stable latest support
@@ -64,9 +67,12 @@ jobs:
             sed -i '/<\/widget>/i \    <preference name="android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.12-bin.zip" \/>' cordova/config.xml
           fi
 
-      - name: Ensure cordova vibration plugin is installed
+      - name: Install Cordova plugins
         working-directory: cordova
         run: |
+          cordova plugin add cordova-plugin-screen-orientation || true
+          cordova plugin add cordova-plugin-fullscreen || true
+          cordova plugin add cordova-plugin-statusbar || true
           cordova plugin add cordova-plugin-vibration || true
 
       - name: Prepare Cordova www

--- a/config.xml
+++ b/config.xml
@@ -27,6 +27,13 @@
     <platform name="android">
         <preference name="FullScreen" value="true" />
         <preference name="Orientation" value="portrait" />
+        <preference name="AndroidLaunchMode" value="singleTask" />
+        <!-- Handle config changes in-app so orientation change doesn't restart the activity -->
+        <edit-config file="AndroidManifest.xml" target="/manifest/application/activity" mode="merge">
+            <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+                      android:screenOrientation="portrait"
+                      xmlns:android="http://schemas.android.com/apk/res/android" />
+        </edit-config>
     </platform>
 
     <platform name="ios">

--- a/src/main.js
+++ b/src/main.js
@@ -94,14 +94,18 @@ history.pushState(null, "", location.href);
 // ---------------------------------------------------------------------------
 // Cordova-specific plugin setup
 // ---------------------------------------------------------------------------
-function setupCordovaPlugins() {
-    // Enable Android immersive fullscreen via cordova-plugin-fullscreen
+function enterImmersiveSticky() {
     if (window.AndroidFullScreen) {
         window.AndroidFullScreen.immersiveMode(
             function () { lockPortrait(); },
             function () {}
         );
     }
+}
+
+function setupCordovaPlugins() {
+    // Enable Android immersive fullscreen via cordova-plugin-fullscreen
+    enterImmersiveSticky();
 
     // Hide status bar via cordova-plugin-statusbar
     if (window.StatusBar) {
@@ -109,6 +113,18 @@ function setupCordovaPlugins() {
     }
 
     lockPortrait();
+
+    // Re-enter immersive mode whenever the app resumes from background
+    document.addEventListener("resume", function () {
+        enterImmersiveSticky();
+        if (window.StatusBar) { window.StatusBar.hide(); }
+        lockPortrait();
+    }, false);
+
+    // Prevent the Android back gesture / button from closing the app
+    document.addEventListener("backbutton", function (e) {
+        e.preventDefault();
+    }, false);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/scenes/LoadScene.js
+++ b/src/scenes/LoadScene.js
@@ -214,20 +214,20 @@ export class LoadScene extends BaseScene {
 
     loadStart(lowModeFlg) {
         if (typeof document !== "undefined") {
-            // Prefer Cordova fullscreen plugin (Android immersive mode)
+            // Prefer Cordova fullscreen plugin (Android immersive sticky mode)
             if (window.AndroidFullScreen) {
                 window.AndroidFullScreen.immersiveMode(
                     function () {
                         log("Immersive fullscreen enabled");
-                        // Lock orientation after immersive mode is active
                         if (window.screen && window.screen.orientation && window.screen.orientation.lock) {
                             window.screen.orientation.lock("portrait").catch(function () {});
                         }
                     },
                     function () { log("Immersive fullscreen not available"); }
                 );
-            } else {
-                // Browser fullscreen — lock orientation in the success callback
+            } else if (!window.cordova) {
+                // Browser fullscreen — only attempt when NOT running inside Cordova
+                // (Cordova handles fullscreen natively via config.xml preferences)
                 const element = document.querySelector("#canvas canvas") || document.documentElement;
                 const requestMethod = element.requestFullscreen
                     || element.webkitRequestFullscreen


### PR DESCRIPTION
The deploy workflow was creating a fresh Cordova project without copying the
repo config.xml or installing the declared plugins (screen-orientation,
fullscreen, statusbar). This meant the APK shipped without native portrait
lock, immersive mode, or status bar hiding — all the JS plugin calls were
silently failing because the plugins were absent.

Changes:
- deploy.yml: copy config.xml into Cordova project and install all plugins
- config.xml: add edit-config to set android:screenOrientation=portrait and
  android:configChanges directly in AndroidManifest.xml so orientation
  changes never restart the activity
- main.js: extract enterImmersiveSticky(), re-enter immersive mode on
  Cordova resume event, handle backbutton to prevent back-gesture exit
- LoadScene.js: skip browser fullscreen API when running inside Cordova
  (native fullscreen is handled by config.xml preferences)

https://claude.ai/code/session_01122fBCbaJN9VB4oywjyiSP