### PR TITLE
Fix fullscreen exit and rotation on left-edge swipe

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
             touch-action: none;
             -webkit-overflow-scrolling: auto;
             -ms-touch-action: none;
+            /* Prevent text/element selection on swipe gestures */
+            user-select: none;
+            -webkit-user-select: none;
+            /* Suppress iOS long-press callout (copy/paste bubble) */
+            -webkit-touch-callout: none;
         }
 
         #canvas {


### PR DESCRIPTION
- Switch AndroidFullScreen.immersiveMode → immersiveStickyMode so system bars auto-hide after a brief appearance instead of keeping fullscreen permanently dismissed; fall back to immersiveMode if unavailable.
- Add Cordova backbutton handler to prevent Android back-swipe from exiting the app; re-asserts immersive sticky mode on each press.
- Add Cordova resume handler to re-apply fullscreen and orientation after the app returns from the background.
- Add orientationchange listener to immediately re-lock portrait and re-enter fullscreen if the OS drops the orientation lock mid-transition.
- Increase edge-swipe EDGE_PX threshold 30 → 50 px for wider coverage.
- Track touchStartedAtEdge flag so the entire gesture is suppressed (not just events whose current position is near the edge); reset on touchend/touchcancel.
- Add user-select/webkit-user-select: none and -webkit-touch-callout: none to CSS to prevent selection/callout popups triggered by edge swipes.

https://claude.ai/code/session_01QLdYpNKJYrVMvuuCsFYZ4R