### PR TITLE
Fix Cordova build and harden immersive mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,9 +71,11 @@ jobs:
         working-directory: cordova
         run: |
           cordova plugin add cordova-plugin-screen-orientation || true
-          cordova plugin add cordova-plugin-fullscreen || true
           cordova plugin add cordova-plugin-statusbar || true
           cordova plugin add cordova-plugin-vibration || true
+
+      - name: Copy hooks into Cordova project
+        run: cp -r hooks cordova/hooks
 
       - name: Prepare Cordova www
         run: |

--- a/config.xml
+++ b/config.xml
@@ -21,8 +21,10 @@
     <preference name="SuppressesIncrementalRendering" value="false" />
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
 
-    <!-- Android: immersive sticky mode (hides nav/status bars) -->
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
+
+    <!-- Immersive sticky mode is applied via hooks/after_prepare.js (patches MainActivity.kt) -->
+    <hook type="after_prepare" src="hooks/after_prepare.js" />
 
     <platform name="android">
         <preference name="FullScreen" value="true" />
@@ -32,6 +34,7 @@
         <edit-config file="AndroidManifest.xml" target="/manifest/application/activity" mode="merge">
             <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
                       android:screenOrientation="portrait"
+                      android:resizeableActivity="false"
                       xmlns:android="http://schemas.android.com/apk/res/android" />
         </edit-config>
     </platform>
@@ -44,6 +47,5 @@
 
     <!-- Plugins -->
     <plugin name="cordova-plugin-screen-orientation" spec="^3.0.4" />
-    <plugin name="cordova-plugin-fullscreen" spec="^1.3.0" />
     <plugin name="cordova-plugin-statusbar" spec="^4.0.0" />
 </widget>

--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+/**
+ * Cordova after_prepare hook
+ *
+ * Patches MainActivity.kt (cordova-android 13+) to enable Android immersive
+ * sticky mode.  This replaces the old cordova-plugin-fullscreen which only
+ * supported Java-based CordovaActivity projects.
+ *
+ * The patched activity:
+ *  - Hides both status bar and navigation bar on launch.
+ *  - Re-hides them whenever the window regains focus (e.g. after a swipe
+ *    gesture momentarily reveals the bars).
+ *  - Uses the modern WindowInsetsController API (API 30+) with a legacy
+ *    fallback for older devices.
+ */
+
+const fs   = require("fs");
+const path = require("path");
+
+/** Recursively search for a file by name under `dir`. */
+function findFile(dir, filename) {
+    let entries;
+    try { entries = fs.readdirSync(dir); } catch (_) { return null; }
+
+    for (const entry of entries) {
+        const full = path.join(dir, entry);
+        let stat;
+        try { stat = fs.statSync(full); } catch (_) { continue; }
+
+        if (stat.isDirectory()) {
+            const found = findFile(full, filename);
+            if (found) return found;
+        } else if (entry === filename) {
+            return full;
+        }
+    }
+    return null;
+}
+
+module.exports = function (context) {
+    const platformRoot = path.join(
+        context.opts.projectRoot, "platforms", "android"
+    );
+    if (!fs.existsSync(platformRoot)) return;
+
+    const mainActivity = findFile(
+        path.join(platformRoot, "app", "src"), "MainActivity.kt"
+    );
+    if (!mainActivity) {
+        console.warn(
+            "after_prepare hook: MainActivity.kt not found – skipping immersive-mode patch"
+        );
+        return;
+    }
+
+    let src = fs.readFileSync(mainActivity, "utf8");
+
+    // Guard against patching twice
+    if (src.includes("enterImmersiveMode")) return;
+
+    // ---- Add required imports --------------------------------------------------
+    const importsToAdd = [
+        "import android.os.Build",
+        "import android.view.View",
+        "import android.view.WindowInsets",
+        "import android.view.WindowInsetsController"
+    ].join("\n");
+
+    // Insert right after the existing CordovaActivity import line
+    src = src.replace(
+        /(import\s+org\.apache\.cordova\.\*)/,
+        "$1\n" + importsToAdd
+    );
+
+    // ---- Add enterImmersiveMode() + onWindowFocusChanged() ---------------------
+    const methodBlock = `
+    private fun enterImmersiveMode() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.insetsController?.let { controller ->
+                controller.hide(WindowInsets.Type.systemBars())
+                controller.systemBarsBehavior =
+                    WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    or View.SYSTEM_UI_FLAG_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            )
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            enterImmersiveMode()
+        }
+    }`;
+
+    // Call enterImmersiveMode() right after loadUrl in onCreate
+    src = src.replace(
+        /(loadUrl\(launchUrl\))/,
+        "$1\n        enterImmersiveMode()"
+    );
+
+    // Insert methods before the final closing brace of the class
+    const lastBrace = src.lastIndexOf("}");
+    src = src.substring(0, lastBrace) + methodBlock + "\n}\n";
+
+    fs.writeFileSync(mainActivity, src, "utf8");
+    console.log("after_prepare hook: patched MainActivity.kt with immersive sticky mode");
+};

--- a/src/main.js
+++ b/src/main.js
@@ -94,19 +94,11 @@ history.pushState(null, "", location.href);
 // ---------------------------------------------------------------------------
 // Cordova-specific plugin setup
 // ---------------------------------------------------------------------------
-function enterImmersiveSticky() {
-    if (window.AndroidFullScreen) {
-        window.AndroidFullScreen.immersiveMode(
-            function () { lockPortrait(); },
-            function () {}
-        );
-    }
-}
+// Immersive sticky mode (hiding status + nav bars, re-hiding after swipe) is
+// handled natively by the patched MainActivity.kt (see hooks/after_prepare.js).
+// The JS side only needs to lock portrait and hide the status bar plugin.
 
 function setupCordovaPlugins() {
-    // Enable Android immersive fullscreen via cordova-plugin-fullscreen
-    enterImmersiveSticky();
-
     // Hide status bar via cordova-plugin-statusbar
     if (window.StatusBar) {
         window.StatusBar.hide();
@@ -114,9 +106,8 @@ function setupCordovaPlugins() {
 
     lockPortrait();
 
-    // Re-enter immersive mode whenever the app resumes from background
+    // Re-apply after the app resumes from background
     document.addEventListener("resume", function () {
-        enterImmersiveSticky();
         if (window.StatusBar) { window.StatusBar.hide(); }
         lockPortrait();
     }, false);


### PR DESCRIPTION
This submission fixes Cordova build failures caused by the incompatible cordova-plugin-fullscreen on modern Android versions. It replaces the plugin with a native Kotlin implementation injected via a Cordova `after_prepare` hook. It also hardens the orientation lock for Android 15+ and cleans up the application entry point.

---
*PR created automatically by Jules for task [12900991766056735369](https://jules.google.com/task/12900991766056735369) started by @easierbycode*