### PR TITLE
Remove cordova-plugin-statusbar and cordova-plugin-vibration to fix Android build

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -45,7 +45,8 @@
         <preference name="DisallowOverscroll" value="true" />
     </platform>
 
-    <!-- Plugins -->
-    <plugin name="cordova-plugin-statusbar" spec="^4.0.0" />
-    <plugin name="cordova-plugin-vibration" spec="^3.1.1" />
+    <!-- Plugins removed: cordova-plugin-statusbar and cordova-plugin-vibration
+         are incompatible with cordova-android 13+ (Kotlin-based MainActivity).
+         Status bar hiding is handled natively via hooks/after_prepare.js.
+         Vibration is available via the Web Vibration API (navigator.vibrate). -->
 </widget>

--- a/src/main.js
+++ b/src/main.js
@@ -96,19 +96,13 @@ history.pushState(null, "", location.href);
 // ---------------------------------------------------------------------------
 // Immersive sticky mode (hiding status + nav bars, re-hiding after swipe) is
 // handled natively by the patched MainActivity.kt (see hooks/after_prepare.js).
-// The JS side only needs to lock portrait and hide the status bar plugin.
+// The JS side only needs to lock portrait orientation.
 
 function setupCordovaPlugins() {
-    // Hide status bar via cordova-plugin-statusbar
-    if (window.StatusBar) {
-        window.StatusBar.hide();
-    }
-
     lockPortrait();
 
     // Re-apply after the app resumes from background
     document.addEventListener("resume", function () {
-        if (window.StatusBar) { window.StatusBar.hide(); }
         lockPortrait();
     }, false);
 


### PR DESCRIPTION
These plugins use Java-based install hooks that are incompatible with
cordova-android 13+ (which uses Kotlin-based MainActivity.kt), causing
"No Java files found that extend CordovaActivity" during build.

Status bar hiding is already handled natively by the after_prepare.js
hook (immersive sticky mode). Vibration is unused in the codebase and
available via the Web Vibration API if needed.

https://claude.ai/code/session_01A4TLrhwpsKVpe3qP45VZPr