### PR TITLE
Fix CordovaActivity error: align config.xml widget id with cordova create package name

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.example.sf2019" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.easierbycode.game2019es7" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>2019-es7</name>
     <description>Street Fighter browser game</description>
     <content src="index.html" />


### PR DESCRIPTION
The CI cordova create command uses com.easierbycode.game2019es7 but
config.xml had com.example.sf2019. When config.xml is copied over the
generated one, cordova prepare detects the package name mismatch and
tries to move MainActivity.kt to a new namespace path — but fails to
recreate it, causing "No Java files found that extend CordovaActivity".

https://claude.ai/code/session_016ScDYyP5g4ABc9vJCx1GvM