### PR TITLE
Fix appcompat-1.7.0 resource compilation: set compileSdkVersion to 35

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,12 @@ jobs:
           else
             sed -i '/<\/widget>/i \    <preference name="android-targetSdkVersion" value="35" \/>' cordova/config.xml
           fi
+          # Set compile-sdk to 35 so AAPT2 can handle appcompat-1.7.0 HalfFloat colors
+          if grep -q "android-compileSdkVersion" cordova/config.xml; then
+            sed -i 's/android-compileSdkVersion" value="[0-9]*"/android-compileSdkVersion" value="35"/' cordova/config.xml
+          else
+            sed -i '/<\/widget>/i \    <preference name="android-compileSdkVersion" value="35" \/>' cordova/config.xml
+          fi
           # Pin Gradle version to 8.12 to avoid failures with non-existent versions like 8.13
           if grep -q "android-gradle-distribution-url" cordova/config.xml; then
             sed -i 's|android-gradle-distribution-url" value=".*"|android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.12-bin.zip"|' cordova/config.xml

--- a/config.xml
+++ b/config.xml
@@ -22,6 +22,7 @@
     <preference name="KeyboardDisplayRequiresUserAction" value="true" />
 
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
+    <preference name="android-compileSdkVersion" value="35" />
 
     <!-- Immersive sticky mode is applied via hooks/after_prepare.js (patches MainActivity.kt) -->
     <hook type="after_prepare" src="hooks/after_prepare.js" />


### PR DESCRIPTION
appcompat-1.7.0 uses HalfFloat color values that require AAPT2 from compileSdk 35+. Cordova-android defaults to compileSdk 34, causing "Invalid <color> for given resource value" during mergeDebugResources.

https://claude.ai/code/session_016ScDYyP5g4ABc9vJCx1GvM