### PR TITLE
Pin AndroidX AppCompat to 1.6.1 to avoid Android resource merge failure

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,6 +23,8 @@
 
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
     <preference name="android-compileSdkVersion" value="35" />
+    <!-- Pin appcompat to 1.6.1 to avoid AAPT2 resource parsing failures seen with 1.7.0 in CI -->
+    <preference name="AndroidXAppCompatVersion" value="1.6.1" />
 
     <!-- Immersive sticky mode is applied via hooks/after_prepare.js (patches MainActivity.kt) -->
     <hook type="after_prepare" src="hooks/after_prepare.js" />


### PR DESCRIPTION
### Motivation
- Address the `:app:mergeDebugResources` failure caused by resource compilation/AAPT2 issues in `appcompat-1.7.0` by pinning a known-good AppCompat version for Cordova Android builds.

### Description
- Add a Cordova Android preference to `config.xml`: `<preference name="AndroidXAppCompatVersion" value="1.6.1" />` so the project uses AppCompat `1.6.1` without changing runtime game code.

### Testing
- Verified `config.xml` is well-formed by running `python3 -c "import xml.etree.ElementTree as ET; ET.parse('config.xml')"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1025195bc83329f8f4f9c8dc08129)