### PR TITLE
config.xml: fix BackgroundColor format and pin AndroidX AppCompat to 1.6.1

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -12,7 +12,7 @@
     <preference name="DisallowOverscroll" value="true" />
     <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarStyle" value="default" />
-    <preference name="BackgroundColor" value="0xff000000" />
+    <preference name="BackgroundColor" value="#ff000000" />
     <preference name="KeepRunning" value="true" />
 
     <!-- iOS: disable swipe-back/forward navigation gesture -->
@@ -23,6 +23,8 @@
 
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
     <preference name="android-compileSdkVersion" value="35" />
+    <!-- Pin appcompat to 1.6.1 to avoid AAPT2 resource parsing failures seen with 1.7.0 in CI -->
+    <preference name="AndroidXAppCompatVersion" value="1.6.1" />
 
     <!-- Immersive sticky mode is applied via hooks/after_prepare.js (patches MainActivity.kt) -->
     <hook type="after_prepare" src="hooks/after_prepare.js" />


### PR DESCRIPTION
### Motivation
- Ensure the Android build uses a valid hex color format for the background and avoid AAPT2 resource parsing failures caused by AppCompat 1.7.0 in CI by pinning to a known-good version.

### Description
- Replace `BackgroundColor` value from `0xff000000` to `#ff000000` in `config.xml` to use a proper hex color notation.
- Add `AndroidXAppCompatVersion` preference set to `1.6.1` with an explanatory comment to force appcompat 1.6.1 and avoid AAPT2 parsing issues seen with 1.7.0.

### Testing
- Ran `cordova prepare` and `cordova build android` in CI to validate the Android project setup and the change; the build completed successfully.
- XML configuration was validated by the Cordova tooling during `cordova prepare` and reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1025195bc83329f8f4f9c8dc08129)