### PR TITLE
Fix frame-rate-dependent game speed across devices

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+export default {
+    server:
+        {
+            allowedHosts: [
+                "localhost",
+                "ermelinda-preelectric-mutably.ngrok-free.dev"
+            ]
+        }
+}


### PR DESCRIPTION
## Summary
- **Fixed timestep accumulator** in `BaseScene._onTick()` ensures exactly 120 logic updates/sec using `performance.now()` wall-clock timing, regardless of display refresh rate (30Hz battery saver → 120Hz high-refresh)
- **Removed `ticker.stop()` from `sceneRemoved()`** which was killing the shared PIXI ticker and breaking `_onTick` dispatch after scene transitions
- Added `vite.config.js` with `allowedHosts` for local/ngrok dev serving

## Test plan
- [ ] Verify game speed is consistent on iPhone XR / Android in Battery Saver mode (~30Hz)
- [ ] Verify game speed is consistent on 60Hz and 120Hz displays
- [ ] Verify scene transitions (mode select → loading → title → gameplay) don't freeze the game loop
- [ ] Verify horizontal movement speed feels the same across all refresh rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)