### PR TITLE
Fix Canvas2D readback performance warning in TextMetrics

### DIFF
--- a/src/lib/pixi.js
+++ b/src/lib/pixi.js
@@ -24100,7 +24100,7 @@ TextMetrics._canvas = canvas;
  * @type {CanvasRenderingContext2D}
  * @private
  */
-TextMetrics._context = canvas.getContext('2d');
+TextMetrics._context = canvas.getContext('2d', { willReadFrequently: true });
 
 /**
  * Cache of PIXI.TextMetrics~FontMetrics objects.


### PR DESCRIPTION
- Add `willReadFrequently: true` option to canvas context creation in TextMetrics
- This suppresses the Canvas2D readback performance warning since TextMetrics frequently reads from the canvas context
- Changes `canvas.getContext('2d')` to `canvas.getContext('2d', { willReadFrequently: true })`