### PR TITLE
Fix Phaser mode loading hang

### DIFF
--- a/src/phaser/EndingScene.js
+++ b/src/phaser/EndingScene.js
@@ -30,10 +30,10 @@ export class PhaserEndingScene extends Phaser.Scene {
 
         this.playSound("voice_congra", 0.7);
 
-        var congraTitle = this.add.sprite(GCX, 60, "game_ui", "congraTitle.gif");
+        var congraTitle = this.add.sprite(GCX, 60, "game_ui", "congraTxt0.gif");
         congraTitle.setOrigin(0.5);
 
-        var congraFace = this.add.sprite(GCX, 160, "game_ui", "congraFace.gif");
+        var congraFace = this.add.sprite(GCX, 160, "game_ui", "congraBg0.gif");
         congraFace.setOrigin(0.5);
 
         var scoreLabel = LANG === "ja" ? "スコア" : "SCORE";

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -22,17 +22,17 @@ export class PhaserTitleScene extends Phaser.Scene {
         );
         this.bg.setOrigin(0, 0);
 
-        this.titleG = this.add.sprite(0, 0, "title_ui", "titleG.gif");
+        this.titleG = this.add.sprite(0, 0, "game_ui", "titleG.gif");
         this.titleG.setOrigin(0, 0);
         this.titleG.setPosition(GAME_DIMENSIONS.WIDTH, 100);
 
-        this.logo = this.add.sprite(0, 0, "title_ui", "logo.gif");
+        this.logo = this.add.sprite(0, 0, "game_ui", "logo.gif");
         this.logo.setOrigin(0.5);
         this.logo.setPosition(this.logo.width / 2, -this.logo.height / 2);
         this.logo.setScale(2);
 
         var subtitleKey = "subTitle" + (LANG === "ja" ? "" : "En") + ".gif";
-        this.subTitle = this.add.sprite(0, 0, "title_ui", subtitleKey);
+        this.subTitle = this.add.sprite(0, 0, "game_ui", subtitleKey);
         this.subTitle.setOrigin(0.5);
         this.subTitle.setPosition(this.subTitle.width / 2, -this.logo.height / 2);
         this.subTitle.setScale(3);
@@ -43,17 +43,17 @@ export class PhaserTitleScene extends Phaser.Scene {
 
         this.startText = this.add.sprite(
             GAME_DIMENSIONS.CENTER_X, 330,
-            "title_ui", "titleStartText.gif"
+            "game_ui", "titleStartText.gif"
         );
         this.startText.setOrigin(0.5);
         this.startText.setAlpha(0);
         this.startText.setInteractive({ useHandCursor: true });
 
-        this.copyright = this.add.sprite(0, 0, "title_ui", "titleCopyright.gif");
+        this.copyright = this.add.sprite(0, 0, "game_ui", "titleCopyright.gif");
         this.copyright.setOrigin(0, 0);
         this.copyright.y = GAME_DIMENSIONS.HEIGHT - this.copyright.height - 6;
 
-        this.scoreTitleImg = this.add.sprite(32, 0, "title_ui", "hiScoreTxt.gif");
+        this.scoreTitleImg = this.add.sprite(32, 0, "game_ui", "hiScoreTxt.gif");
         this.scoreTitleImg.setOrigin(0, 0);
         this.scoreTitleImg.y = this.copyright.y - 58;
 


### PR DESCRIPTION
The game was hanging at 100% loading in Phaser mode because `PhaserTitleScene` was trying to load assets from the `title_ui` atlas, but they are actually defined in the `game_ui` atlas. I corrected these references in `src/phaser/TitleScene.js`. Additionally, I fixed some incorrect frame names in `src/phaser/EndingScene.js` that were also pointing to missing assets. These corrections ensure that the Phaser scenes can initialize properly without throwing runtime errors during asset creation.

---
*PR created automatically by Jules for task [18361887623689922054](https://jules.google.com/task/18361887623689922054) started by @easierbycode*