### PR TITLE
Fix PIXI SP mode audio loading and title button taps

### DIFF
--- a/src/scenes/LoadScene.js
+++ b/src/scenes/LoadScene.js
@@ -161,7 +161,8 @@ export class LoadScene extends BaseScene {
         this.playSpBtn.x = 44;
         this.playSpBtn.y = this.playPcTxt.y + 20;
         this.addChild(this.playSpBtn);
-        this.playSpBtn.on("pointerup", this.loadStart.bind(this, true));
+        // Keep SP mode on PIXI while still loading full assets (including audio).
+        this.playSpBtn.on("pointerup", this.loadStart.bind(this, false));
 
         this.playSpTxt = new PIXI.Sprite(PIXI.Texture.fromFrame("playBtnSpTxt.gif"));
         this.playSpTxt.x = 44;

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -108,7 +108,7 @@ export class TitleScene extends BaseScene {
         this.startBtn.buttonMode = false;
         this.startBtn.alpha = 0;
         this.addChild(this.startBtn);
-        this.startBtn.on("pointerup", this._onStartUp);
+        this.startBtn.on("pointertap", this._onStartUp);
 
         this.copyright = new PIXI.Sprite(frameTexture("titleCopyright.gif"));
         this.copyright.x = 0;
@@ -144,7 +144,7 @@ export class TitleScene extends BaseScene {
         this.twitterBtn.x = GAME_DIMENSIONS.CENTER_X;
         this.twitterBtn.y = this.copyright.y - this.twitterBtn.height / 2 - 14;
         this.addChild(this.twitterBtn);
-        this.twitterBtn.on("pointerup", this._onTweetUp);
+        this.twitterBtn.on("pointertap", this._onTweetUp);
 
         this.howtoBtn = new HowtoButton();
         this.howtoBtn.x = 15;
@@ -157,7 +157,7 @@ export class TitleScene extends BaseScene {
         this.staffrollBtn.y = 10;
         this.staffrollBtn.scale.y = 0;
         this.addChild(this.staffrollBtn);
-        this.staffrollBtn.on("pointerup", this._onStaffrollUp);
+        this.staffrollBtn.on("pointertap", this._onStaffrollUp);
 
         const coverTexture = frameTexture("stagebgOver.gif");
         this.cover = new PIXI.extras.TilingSprite(coverTexture, STAGE_DIMENSIONS.WIDTH, STAGE_DIMENSIONS.HEIGHT);
@@ -350,13 +350,13 @@ export class TitleScene extends BaseScene {
         }
 
         if (this.startBtn) {
-            this.startBtn.off("pointerup", this._onStartUp);
+            this.startBtn.off("pointertap", this._onStartUp);
         }
         if (this.twitterBtn) {
-            this.twitterBtn.off("pointerup", this._onTweetUp);
+            this.twitterBtn.off("pointertap", this._onTweetUp);
         }
         if (this.staffrollBtn) {
-            this.staffrollBtn.off("pointerup", this._onStaffrollUp);
+            this.staffrollBtn.off("pointertap", this._onStaffrollUp);
         }
 
         if (this.staffrollPanel && this.staffrollPanel.parent) {


### PR DESCRIPTION
### Motivation
- Ensure SP mode on the PIXI path starts with full assets (including audio) so sound plays, and make title screen buttons reliable on touch devices where `pointerup` was not consistently firing.

### Description
- Call `this.loadStart(false)` for the SP mode button in `src/scenes/LoadScene.js` to avoid starting in low/audio-disabled mode, and switch TitleScene handlers for Start/Twitter/Staffroll from `pointerup` to `pointertap` (including listener cleanup) in `src/scenes/TitleScene.js`.

### Testing
- Ran syntax checks with `node --check src/scenes/LoadScene.js` and `node --check src/scenes/TitleScene.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667d5b95483329bf5baee34ef66e5)