### PR TITLE
Use unified `game_ui` atlas, switch PIXI handlers to `pointertap`, and keep SP mode on PIXI during load

### DIFF
--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -22,17 +22,17 @@ export class PhaserTitleScene extends Phaser.Scene {
         );
         this.bg.setOrigin(0, 0);
 
-        this.titleG = this.add.sprite(0, 0, "title_ui", "titleG.gif");
+        this.titleG = this.add.sprite(0, 0, "game_ui", "titleG.gif");
         this.titleG.setOrigin(0, 0);
         this.titleG.setPosition(GAME_DIMENSIONS.WIDTH, 100);
 
-        this.logo = this.add.sprite(0, 0, "title_ui", "logo.gif");
+        this.logo = this.add.sprite(0, 0, "game_ui", "logo.gif");
         this.logo.setOrigin(0.5);
         this.logo.setPosition(this.logo.width / 2, -this.logo.height / 2);
         this.logo.setScale(2);
 
         var subtitleKey = "subTitle" + (LANG === "ja" ? "" : "En") + ".gif";
-        this.subTitle = this.add.sprite(0, 0, "title_ui", subtitleKey);
+        this.subTitle = this.add.sprite(0, 0, "game_ui", subtitleKey);
         this.subTitle.setOrigin(0.5);
         this.subTitle.setPosition(this.subTitle.width / 2, -this.logo.height / 2);
         this.subTitle.setScale(3);
@@ -43,17 +43,17 @@ export class PhaserTitleScene extends Phaser.Scene {
 
         this.startText = this.add.sprite(
             GAME_DIMENSIONS.CENTER_X, 330,
-            "title_ui", "titleStartText.gif"
+            "game_ui", "titleStartText.gif"
         );
         this.startText.setOrigin(0.5);
         this.startText.setAlpha(0);
         this.startText.setInteractive({ useHandCursor: true });
 
-        this.copyright = this.add.sprite(0, 0, "title_ui", "titleCopyright.gif");
+        this.copyright = this.add.sprite(0, 0, "game_ui", "titleCopyright.gif");
         this.copyright.setOrigin(0, 0);
         this.copyright.y = GAME_DIMENSIONS.HEIGHT - this.copyright.height - 6;
 
-        this.scoreTitleImg = this.add.sprite(32, 0, "title_ui", "hiScoreTxt.gif");
+        this.scoreTitleImg = this.add.sprite(32, 0, "game_ui", "hiScoreTxt.gif");
         this.scoreTitleImg.setOrigin(0, 0);
         this.scoreTitleImg.y = this.copyright.y - 58;
 

--- a/src/scenes/LoadScene.js
+++ b/src/scenes/LoadScene.js
@@ -161,7 +161,8 @@ export class LoadScene extends BaseScene {
         this.playSpBtn.x = 44;
         this.playSpBtn.y = this.playPcTxt.y + 20;
         this.addChild(this.playSpBtn);
-        this.playSpBtn.on("pointerup", this.loadStart.bind(this, true));
+        // Keep SP mode on PIXI while still loading full assets (including audio).
+        this.playSpBtn.on("pointerup", this.loadStart.bind(this, false));
 
         this.playSpTxt = new PIXI.Sprite(PIXI.Texture.fromFrame("playBtnSpTxt.gif"));
         this.playSpTxt.x = 44;

--- a/src/scenes/TitleScene.js
+++ b/src/scenes/TitleScene.js
@@ -108,7 +108,7 @@ export class TitleScene extends BaseScene {
         this.startBtn.buttonMode = false;
         this.startBtn.alpha = 0;
         this.addChild(this.startBtn);
-        this.startBtn.on("pointerup", this._onStartUp);
+        this.startBtn.on("pointertap", this._onStartUp);
 
         this.copyright = new PIXI.Sprite(frameTexture("titleCopyright.gif"));
         this.copyright.x = 0;
@@ -144,7 +144,7 @@ export class TitleScene extends BaseScene {
         this.twitterBtn.x = GAME_DIMENSIONS.CENTER_X;
         this.twitterBtn.y = this.copyright.y - this.twitterBtn.height / 2 - 14;
         this.addChild(this.twitterBtn);
-        this.twitterBtn.on("pointerup", this._onTweetUp);
+        this.twitterBtn.on("pointertap", this._onTweetUp);
 
         this.howtoBtn = new HowtoButton();
         this.howtoBtn.x = 15;
@@ -157,7 +157,7 @@ export class TitleScene extends BaseScene {
         this.staffrollBtn.y = 10;
         this.staffrollBtn.scale.y = 0;
         this.addChild(this.staffrollBtn);
-        this.staffrollBtn.on("pointerup", this._onStaffrollUp);
+        this.staffrollBtn.on("pointertap", this._onStaffrollUp);
 
         const coverTexture = frameTexture("stagebgOver.gif");
         this.cover = new PIXI.extras.TilingSprite(coverTexture, STAGE_DIMENSIONS.WIDTH, STAGE_DIMENSIONS.HEIGHT);
@@ -350,13 +350,13 @@ export class TitleScene extends BaseScene {
         }
 
         if (this.startBtn) {
-            this.startBtn.off("pointerup", this._onStartUp);
+            this.startBtn.off("pointertap", this._onStartUp);
         }
         if (this.twitterBtn) {
-            this.twitterBtn.off("pointerup", this._onTweetUp);
+            this.twitterBtn.off("pointertap", this._onTweetUp);
         }
         if (this.staffrollBtn) {
-            this.staffrollBtn.off("pointerup", this._onStaffrollUp);
+            this.staffrollBtn.off("pointertap", this._onStaffrollUp);
         }
 
         if (this.staffrollPanel && this.staffrollPanel.parent) {


### PR DESCRIPTION
### Motivation

- Consolidate sprite atlas usage in the Phaser title scene by switching assets to the shared `game_ui` atlas.
- Improve input reliability for PIXI interactive buttons by using the `pointertap` event instead of `pointerup`.
- Prevent an early switch to Phaser when starting SP mode by keeping SP mode on PIXI while finishing full asset loading.

### Description

- Replaced `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a667d5b95483329bf5baee34ef66e5)