### PR TITLE
Guard keyboard init and add tap fallback to prevent frozen Phaser scenes

### DIFF
--- a/src/phaser/AdvScene.js
+++ b/src/phaser/AdvScene.js
@@ -158,9 +158,26 @@ export class PhaserAdvScene extends Phaser.Scene {
             self.onNextPress();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            if (self.partTextComp) {
+                self.onNextPress();
+            }
+        });
+
         // Keyboard: Enter/Space to advance dialogue
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     playSound(key, volume) {
@@ -238,11 +255,12 @@ export class PhaserAdvScene extends Phaser.Scene {
 
     update(time, delta) {
         // Keyboard advance
-        if (this.partTextComp && this.nextBtn && this.nextBtn.visible) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.onNextPress();
-                return;
-            }
+        if (this.partTextComp && this.nextBtn && this.nextBtn.visible && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.onNextPress();
+            return;
         }
 
         if (this.partTextComp || !this.txt) {

--- a/src/phaser/ContinueScene.js
+++ b/src/phaser/ContinueScene.js
@@ -135,9 +135,14 @@ export class PhaserContinueScene extends Phaser.Scene {
         });
 
         // Keyboard: Y for yes, N for no, Enter for yes
-        this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
-        this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        this.yKey = null;
+        this.nKey = null;
+        this.enterKey = null;
+        try {
+            this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
+            this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        } catch (e) {}
 
         this.playBgm("bgm_continue", 0.25);
 
@@ -365,9 +370,10 @@ export class PhaserContinueScene extends Phaser.Scene {
 
         // Keyboard continue controls
         if (this.countActive) {
-            if (Phaser.Input.Keyboard.JustDown(this.yKey) || Phaser.Input.Keyboard.JustDown(this.enterKey)) {
+            if ((this.yKey && Phaser.Input.Keyboard.JustDown(this.yKey))
+                || (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey))) {
                 this.selectYes();
-            } else if (Phaser.Input.Keyboard.JustDown(this.nKey)) {
+            } else if (this.nKey && Phaser.Input.Keyboard.JustDown(this.nKey)) {
                 this.selectNo();
             }
         }

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -138,14 +138,18 @@ export class PhaserGameScene extends Phaser.Scene {
         this.shootSpeed = gameState.shootSpeed || "speed_normal";
 
         // Keyboard controls for PC mode
-        this.cursors = this.input.keyboard.createCursorKeys();
-        this.wasd = this.input.keyboard.addKeys({
-            up: Phaser.Input.Keyboard.KeyCodes.W,
-            down: Phaser.Input.Keyboard.KeyCodes.S,
-            left: Phaser.Input.Keyboard.KeyCodes.A,
-            right: Phaser.Input.Keyboard.KeyCodes.D,
-            sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
-        });
+        this.cursors = null;
+        this.wasd = null;
+        try {
+            this.cursors = this.input.keyboard.createCursorKeys();
+            this.wasd = this.input.keyboard.addKeys({
+                up: Phaser.Input.Keyboard.KeyCodes.W,
+                down: Phaser.Input.Keyboard.KeyCodes.S,
+                left: Phaser.Input.Keyboard.KeyCodes.A,
+                right: Phaser.Input.Keyboard.KeyCodes.D,
+                sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
+            });
+        } catch (e) {}
         this.keyMoveSpeed = 3;
 
         this.stageBgmName = "";
@@ -338,7 +342,7 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     handleKeyboardInput() {
-        if (!this.gameStarted || this.playerDead || this.theWorldFlg) {
+        if (!this.gameStarted || this.playerDead || this.theWorldFlg || !this.cursors || !this.wasd) {
             return;
         }
 
@@ -363,7 +367,7 @@ export class PhaserGameScene extends Phaser.Scene {
         }
 
         // Space bar triggers SP
-        if (Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
+        if (this.wasd.sp && Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
             this.onSpFire();
         }
     }

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -103,6 +103,17 @@ export class PhaserTitleScene extends Phaser.Scene {
             self.titleStart();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            self.titleStart();
+        });
+
         this.fadeRect = this.add.graphics();
         this.fadeRect.fillStyle(0x000000, 1);
         this.fadeRect.fillRect(0, 0, GAME_DIMENSIONS.WIDTH, GAME_DIMENSIONS.HEIGHT);
@@ -112,8 +123,12 @@ export class PhaserTitleScene extends Phaser.Scene {
         this.startIntroAnimation();
 
         // Keyboard: Enter or Space to start
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     startIntroAnimation() {
@@ -273,10 +288,11 @@ export class PhaserTitleScene extends Phaser.Scene {
         }
 
         // Keyboard start
-        if (!this.transitioning) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.titleStart();
-            }
+        if (!this.transitioning && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.titleStart();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Scene creation could throw when calling `Phaser.Input.Keyboard.KeyCodes` (Phaser 4 RC), leaving the scene in an unstarted/frozen state where tweens, `update()` and pointer events never run. 
- The title and adv flows needed a robust touch/click fallback so taps always advance/start even if keyboard APIs are unavailable.

### Description
- Wrapped keyboard initialization in `try/catch` and initialize key variables to `null` for `TitleScene`, `AdvScene`, `ContinueScene`, and `GameScene` so scene `create()` cannot throw (files: `src/phaser/TitleScene.js`, `src/phaser/AdvScene.js`, `src/phaser/ContinueScene.js`, `src/phaser/GameScene.js`).
- Added null-safe checks before calling `Phaser.Input.Keyboard.JustDown(...)` and guarded keyboard-dependent logic in `handleKeyboardInput()` so updates proceed when keyboard bindings are absent.
- Added a full-screen interactive `tapZone` in `TitleScene` and `AdvScene` that triggers `titleStart()` / `onNextPress()` as a fallback for touch/click input.
- Kept existing pointer handlers and keyboard behavior intact when the keyboard API is available.

### Testing
- Ran syntax checks: `node --check src/phaser/TitleScene.js`, `node --check src/phaser/AdvScene.js`, `node --check src/phaser/ContinueScene.js`, and `node --check src/phaser/GameScene.js`, all succeeded.
- Started a local static server and captured the updated title scene via Playwright (screenshot artifact `artifacts/title-scene-fix.png`), confirming the title is responsive to taps/clicks; the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a775bef8a88332b8bcb35f35513b52)