### PR TITLE
Add touch tap zones and defensive input/texture checks for mobile robustness

### DIFF
--- a/src/phaser/AdvScene.js
+++ b/src/phaser/AdvScene.js
@@ -158,9 +158,26 @@ export class PhaserAdvScene extends Phaser.Scene {
             self.onNextPress();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            if (self.partTextComp) {
+                self.onNextPress();
+            }
+        });
+
         // Keyboard: Enter/Space to advance dialogue
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     playSound(key, volume) {
@@ -238,11 +255,12 @@ export class PhaserAdvScene extends Phaser.Scene {
 
     update(time, delta) {
         // Keyboard advance
-        if (this.partTextComp && this.nextBtn && this.nextBtn.visible) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.onNextPress();
-                return;
-            }
+        if (this.partTextComp && this.nextBtn && this.nextBtn.visible && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.onNextPress();
+            return;
         }
 
         if (this.partTextComp || !this.txt) {

--- a/src/phaser/ContinueScene.js
+++ b/src/phaser/ContinueScene.js
@@ -135,9 +135,14 @@ export class PhaserContinueScene extends Phaser.Scene {
         });
 
         // Keyboard: Y for yes, N for no, Enter for yes
-        this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
-        this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        this.yKey = null;
+        this.nKey = null;
+        this.enterKey = null;
+        try {
+            this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
+            this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        } catch (e) {}
 
         this.playBgm("bgm_continue", 0.25);
 
@@ -365,9 +370,10 @@ export class PhaserContinueScene extends Phaser.Scene {
 
         // Keyboard continue controls
         if (this.countActive) {
-            if (Phaser.Input.Keyboard.JustDown(this.yKey) || Phaser.Input.Keyboard.JustDown(this.enterKey)) {
+            if ((this.yKey && Phaser.Input.Keyboard.JustDown(this.yKey))
+                || (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey))) {
                 this.selectYes();
-            } else if (Phaser.Input.Keyboard.JustDown(this.nKey)) {
+            } else if (this.nKey && Phaser.Input.Keyboard.JustDown(this.nKey)) {
                 this.selectNo();
             }
         }

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -138,14 +138,18 @@ export class PhaserGameScene extends Phaser.Scene {
         this.shootSpeed = gameState.shootSpeed || "speed_normal";
 
         // Keyboard controls for PC mode
-        this.cursors = this.input.keyboard.createCursorKeys();
-        this.wasd = this.input.keyboard.addKeys({
-            up: Phaser.Input.Keyboard.KeyCodes.W,
-            down: Phaser.Input.Keyboard.KeyCodes.S,
-            left: Phaser.Input.Keyboard.KeyCodes.A,
-            right: Phaser.Input.Keyboard.KeyCodes.D,
-            sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
-        });
+        this.cursors = null;
+        this.wasd = null;
+        try {
+            this.cursors = this.input.keyboard.createCursorKeys();
+            this.wasd = this.input.keyboard.addKeys({
+                up: Phaser.Input.Keyboard.KeyCodes.W,
+                down: Phaser.Input.Keyboard.KeyCodes.S,
+                left: Phaser.Input.Keyboard.KeyCodes.A,
+                right: Phaser.Input.Keyboard.KeyCodes.D,
+                sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
+            });
+        } catch (e) {}
         this.keyMoveSpeed = 3;
 
         this.stageBgmName = "";
@@ -261,7 +265,12 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     createCover() {
-        this.coverOverlay = this.add.tileSprite(0, 0, GW, GH, "game_ui", "stagebgOver.gif");
+        if (!this.textures.getFrame("game_asset", "stagebgOver.gif")) {
+            this.coverOverlay = null;
+            return;
+        }
+
+        this.coverOverlay = this.add.tileSprite(0, 0, GW, GH, "game_asset", "stagebgOver.gif");
         this.coverOverlay.setOrigin(0, 0);
         this.coverOverlay.setDepth(99);
     }
@@ -338,7 +347,7 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     handleKeyboardInput() {
-        if (!this.gameStarted || this.playerDead || this.theWorldFlg) {
+        if (!this.gameStarted || this.playerDead || this.theWorldFlg || !this.cursors || !this.wasd) {
             return;
         }
 
@@ -363,7 +372,7 @@ export class PhaserGameScene extends Phaser.Scene {
         }
 
         // Space bar triggers SP
-        if (Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
+        if (this.wasd.sp && Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
             this.onSpFire();
         }
     }

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -103,6 +103,17 @@ export class PhaserTitleScene extends Phaser.Scene {
             self.titleStart();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            self.titleStart();
+        });
+
         this.fadeRect = this.add.graphics();
         this.fadeRect.fillStyle(0x000000, 1);
         this.fadeRect.fillRect(0, 0, GAME_DIMENSIONS.WIDTH, GAME_DIMENSIONS.HEIGHT);
@@ -112,8 +123,12 @@ export class PhaserTitleScene extends Phaser.Scene {
         this.startIntroAnimation();
 
         // Keyboard: Enter or Space to start
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     startIntroAnimation() {
@@ -273,10 +288,11 @@ export class PhaserTitleScene extends Phaser.Scene {
         }
 
         // Keyboard start
-        if (!this.transitioning) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.titleStart();
-            }
+        if (!this.transitioning && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.titleStart();
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Enable touch/tap interactions so mobile users can advance the title/adv screens without a keyboard.
- Prevent runtime exceptions when keyboard input or specific texture frames are unavailable in constrained environments.

### Description

- Added full-screen `tapZone` in `PhaserAdvScene` and `PhaserTitleScene` with `pointerup` handlers to advance text and start the title respectively.
- Wrapped keyboard key creation in `try/catch` and initialize key variables to `null` in `PhaserAdvScene`, `PhaserContinueScene`, and `PhaserTitleScene` to avoid crashes when keyboard input is not available.
- Updated input checks to verify key objects exist before calling `Phaser.Input.Keyboard.JustDown`, and added guards for `this.wasd.sp` usage in `PhaserGameScene.handleKeyboardInput`.
- Made `PhaserGameScene.createCover` defensively check for the `stagebgOver.gif` frame in the `game_asset` atlas and early-return if missing, and switched the tile sprite to use `game_asset`.

### Testing

- Ran the project build with `npm run build`, which completed successfully.
- Executed the test suite with `npm test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a775bef8a88332b8bcb35f35513b52)