### PR TITLE
Add touch/tap support, guard keyboard init, enhance loading and HUD UI

### DIFF
--- a/src/phaser/AdvScene.js
+++ b/src/phaser/AdvScene.js
@@ -158,9 +158,26 @@ export class PhaserAdvScene extends Phaser.Scene {
             self.onNextPress();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            if (self.partTextComp) {
+                self.onNextPress();
+            }
+        });
+
         // Keyboard: Enter/Space to advance dialogue
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     playSound(key, volume) {
@@ -238,11 +255,12 @@ export class PhaserAdvScene extends Phaser.Scene {
 
     update(time, delta) {
         // Keyboard advance
-        if (this.partTextComp && this.nextBtn && this.nextBtn.visible) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.onNextPress();
-                return;
-            }
+        if (this.partTextComp && this.nextBtn && this.nextBtn.visible && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.onNextPress();
+            return;
         }
 
         if (this.partTextComp || !this.txt) {

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -11,29 +11,52 @@ export class BootScene extends Phaser.Scene {
         var cx = GAME_DIMENSIONS.CENTER_X;
         var cy = GAME_DIMENSIONS.CENTER_Y;
 
-        var progressBg = this.add.graphics();
-        progressBg.fillStyle(0x222222, 1);
-        progressBg.fillRect(cx - 80, cy - 6, 160, 12);
+        this.loadingBg = null;
+        this.loadingG = null;
+        this.loadingFrameIndex = 0;
 
-        var progressBar = this.add.graphics();
+        var self = this;
 
-        var loadingText = this.add.text(cx, cy - 24, "LOADING...", {
-            fontFamily: "sans-serif",
-            fontSize: "12px",
-            color: "#ffffff",
-        });
-        loadingText.setOrigin(0.5);
+        function ensureLoadingPreview() {
+            if (self.loadingBg || !self.textures.exists("loading_bg") || !self.textures.exists("loading0")) {
+                return;
+            }
 
-        this.load.on("progress", function (value) {
-            progressBar.clear();
-            progressBar.fillStyle(0xffffff, 1);
-            progressBar.fillRect(cx - 78, cy - 4, 156 * value, 8);
-        });
+            self.loadingBg = self.add.image(cx, cy, "loading_bg");
+            self.loadingBg.setAlpha(0.09);
+
+            self.loadingG = self.add.image(cx, cy, "loading0");
+
+            self.time.addEvent({
+                delay: 120,
+                loop: true,
+                callback: function () {
+                    if (!self.loadingG) {
+                        return;
+                    }
+
+                    self.loadingFrameIndex = (self.loadingFrameIndex + 1) % 3;
+                    self.loadingG.setTexture("loading" + String(self.loadingFrameIndex));
+
+                    if (self.loadingBg) {
+                        self.loadingBg.flipX = !self.loadingBg.flipX;
+                    }
+                },
+            });
+        }
+
+        this.load.on("filecomplete-image-loading_bg", ensureLoadingPreview);
+        this.load.on("filecomplete-image-loading0", ensureLoadingPreview);
 
         this.load.on("complete", function () {
-            progressBar.destroy();
-            progressBg.destroy();
-            loadingText.destroy();
+            if (self.loadingG) {
+                self.loadingG.destroy();
+                self.loadingG = null;
+            }
+            if (self.loadingBg) {
+                self.loadingBg.destroy();
+                self.loadingBg = null;
+            }
         });
 
         this.load.atlas("title_ui", "assets/img/title_ui.png", "assets/title_ui.json");
@@ -49,6 +72,9 @@ export class BootScene extends Phaser.Scene {
         }
 
         this.load.image("loading_bg", "assets/img/loading/loading_bg.png");
+        this.load.image("loading0", "assets/img/loading/loading0.gif");
+        this.load.image("loading1", "assets/img/loading/loading1.gif");
+        this.load.image("loading2", "assets/img/loading/loading2.gif");
 
         if (!gameState.lowModeFlg) {
             var soundKeys = Object.keys(RESOURCE_PATHS);

--- a/src/phaser/ContinueScene.js
+++ b/src/phaser/ContinueScene.js
@@ -54,35 +54,24 @@ export class PhaserContinueScene extends Phaser.Scene {
         this.cntText.setOrigin(0, 0);
         this.cntText.setAlpha(0);
 
-        this.yesBtn = this.add.text(
-            GCX - 50, GCY + 70,
-            "YES",
-            {
-                fontFamily: "sans-serif",
-                fontSize: "20px",
-                fontStyle: "bold",
-                color: "#ffffff",
-                backgroundColor: "#003300",
-                padding: { x: 12, y: 8 },
-            }
-        );
-        this.yesBtn.setOrigin(0.5);
-        this.yesBtn.setInteractive({ useHandCursor: true });
+        var self = this;
 
-        this.noBtn = this.add.text(
-            GCX + 50, GCY + 70,
-            "NO",
-            {
-                fontFamily: "sans-serif",
-                fontSize: "20px",
-                fontStyle: "bold",
-                color: "#ffffff",
-                backgroundColor: "#330000",
-                padding: { x: 12, y: 8 },
-            }
-        );
-        this.noBtn.setOrigin(0.5);
-        this.noBtn.setInteractive({ useHandCursor: true });
+        this.yesBtn = this.add.sprite(0, 0, "game_ui", "continueYes.gif");
+        this.yesBtn.setOrigin(0, 0);
+        this.yesBtn.x = GCX - this.yesBtn.width / 2 - 50;
+        this.yesBtn.y = GCY - this.yesBtn.height / 2 + 70;
+
+        this.noBtn = this.add.sprite(0, 0, "game_ui", "continueNo.gif");
+        this.noBtn.setOrigin(0, 0);
+        this.noBtn.x = GCX - this.noBtn.width / 2 + 50;
+        this.noBtn.y = GCY - this.noBtn.height / 2 + 70;
+
+        this.setupContinueButton(this.yesBtn, "continueYes", function () {
+            self.selectYes();
+        });
+        this.setupContinueButton(this.noBtn, "continueNo", function () {
+            self.selectNo();
+        });
 
         this.commentText = this.add.text(
             GCX, GH - 100,
@@ -124,20 +113,15 @@ export class PhaserContinueScene extends Phaser.Scene {
             }
         );
 
-        var self = this;
-
-        this.yesBtn.on("pointerup", function () {
-            self.selectYes();
-        });
-
-        this.noBtn.on("pointerup", function () {
-            self.selectNo();
-        });
-
         // Keyboard: Y for yes, N for no, Enter for yes
-        this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
-        this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        this.yKey = null;
+        this.nKey = null;
+        this.enterKey = null;
+        try {
+            this.yKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Y);
+            this.nKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.N);
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+        } catch (e) {}
 
         this.playBgm("bgm_continue", 0.25);
 
@@ -146,6 +130,25 @@ export class PhaserContinueScene extends Phaser.Scene {
             repeat: 9,
             callback: this.onCountDown,
             callbackScope: this,
+        });
+    }
+
+
+    setupContinueButton(button, framePrefix, onPress) {
+        button.setInteractive({ useHandCursor: true });
+
+        button.on("pointerover", function () {
+            button.setFrame(framePrefix + "Over.gif");
+        });
+        button.on("pointerout", function () {
+            button.setFrame(framePrefix + ".gif");
+        });
+        button.on("pointerdown", function () {
+            button.setFrame(framePrefix + "Down.gif");
+        });
+        button.on("pointerup", function () {
+            button.setFrame(framePrefix + "Over.gif");
+            onPress();
         });
     }
 
@@ -365,9 +368,10 @@ export class PhaserContinueScene extends Phaser.Scene {
 
         // Keyboard continue controls
         if (this.countActive) {
-            if (Phaser.Input.Keyboard.JustDown(this.yKey) || Phaser.Input.Keyboard.JustDown(this.enterKey)) {
+            if ((this.yKey && Phaser.Input.Keyboard.JustDown(this.yKey))
+                || (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey))) {
                 this.selectYes();
-            } else if (Phaser.Input.Keyboard.JustDown(this.nKey)) {
+            } else if (this.nKey && Phaser.Input.Keyboard.JustDown(this.nKey)) {
                 this.selectNo();
             }
         }

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -138,14 +138,18 @@ export class PhaserGameScene extends Phaser.Scene {
         this.shootSpeed = gameState.shootSpeed || "speed_normal";
 
         // Keyboard controls for PC mode
-        this.cursors = this.input.keyboard.createCursorKeys();
-        this.wasd = this.input.keyboard.addKeys({
-            up: Phaser.Input.Keyboard.KeyCodes.W,
-            down: Phaser.Input.Keyboard.KeyCodes.S,
-            left: Phaser.Input.Keyboard.KeyCodes.A,
-            right: Phaser.Input.Keyboard.KeyCodes.D,
-            sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
-        });
+        this.cursors = null;
+        this.wasd = null;
+        try {
+            this.cursors = this.input.keyboard.createCursorKeys();
+            this.wasd = this.input.keyboard.addKeys({
+                up: Phaser.Input.Keyboard.KeyCodes.W,
+                down: Phaser.Input.Keyboard.KeyCodes.S,
+                left: Phaser.Input.Keyboard.KeyCodes.A,
+                right: Phaser.Input.Keyboard.KeyCodes.D,
+                sp: Phaser.Input.Keyboard.KeyCodes.SPACE,
+            });
+        } catch (e) {}
         this.keyMoveSpeed = 3;
 
         this.stageBgmName = "";
@@ -227,20 +231,31 @@ export class PhaserGameScene extends Phaser.Scene {
         );
         this.comboText.setDepth(101);
 
-        this.spGaugeBar = this.add.graphics();
-        this.spGaugeBar.setDepth(102);
-        this.updateSpGauge();
+        this.spBtnWrap = this.add.container(GW - 70, GCY + 15);
+        this.spBtnWrap.setDepth(103);
 
-        this.spBtn = this.add.text(
-            GW - 35, GCY + 20,
-            "SP",
-            { fontFamily: "Arial", fontSize: "14px", fontStyle: "bold", color: "#ff0000", backgroundColor: "#330000", padding: { x: 6, y: 4 } }
-        );
-        this.spBtn.setOrigin(0.5);
-        this.spBtn.setDepth(103);
-        this.spBtn.setInteractive({ useHandCursor: true });
-        this.spBtn.setAlpha(0.3);
-        this.spBtn.on("pointerup", this.onSpFire, this);
+        this.spBtnPulse = this.add.sprite(32, 32, "game_ui", "hudCabtnBg1.gif");
+        this.spBtnPulse.setOrigin(0.5);
+        this.spBtnPulse.setAlpha(0);
+
+        this.spBtnReadyBg = this.add.sprite(-18, -18, "game_ui", "hudCabtnBg0.gif");
+        this.spBtnReadyBg.setOrigin(0, 0);
+        this.spBtnReadyBg.setAlpha(0);
+
+        this.spBtnBarBg = this.add.sprite(0, 0, "game_ui", "hudCabtn100per.gif");
+        this.spBtnBarBg.setOrigin(0, 0);
+
+        this.spBtnBar = this.add.sprite(0, 58, "game_ui", "hudCabtn0per.gif");
+        this.spBtnBar.setOrigin(0, 1);
+        this.spBtnBar.setScale(1, 0);
+
+        this.spBtnWrap.add([this.spBtnPulse, this.spBtnReadyBg, this.spBtnBarBg, this.spBtnBar]);
+        this.spBtnWrap.setSize(this.spBtnBarBg.width, this.spBtnBarBg.height);
+        this.spBtnWrap.setInteractive({ useHandCursor: true });
+        this.spBtnWrap.on("pointerup", this.onSpFire, this);
+
+        this.spReadyTween = null;
+        this.updateSpGauge();
 
         this.bossTimerText = this.add.text(
             GCX, 60,
@@ -261,7 +276,12 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     createCover() {
-        this.coverOverlay = this.add.tileSprite(0, 0, GW, GH, "game_ui", "stagebgOver.gif");
+        if (!this.textures.getFrame("game_asset", "stagebgOver.gif")) {
+            this.coverOverlay = null;
+            return;
+        }
+
+        this.coverOverlay = this.add.tileSprite(0, 0, GW, GH, "game_asset", "stagebgOver.gif");
         this.coverOverlay.setOrigin(0, 0);
         this.coverOverlay.setDepth(99);
     }
@@ -338,7 +358,7 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     handleKeyboardInput() {
-        if (!this.gameStarted || this.playerDead || this.theWorldFlg) {
+        if (!this.gameStarted || this.playerDead || this.theWorldFlg || !this.cursors || !this.wasd) {
             return;
         }
 
@@ -363,17 +383,38 @@ export class PhaserGameScene extends Phaser.Scene {
         }
 
         // Space bar triggers SP
-        if (Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
+        if (this.wasd.sp && Phaser.Input.Keyboard.JustDown(this.wasd.sp)) {
             this.onSpFire();
         }
     }
 
     updateSpGauge() {
-        this.spGaugeBar.clear();
-        this.spGaugeBar.fillStyle(0x333333, 0.7);
-        this.spGaugeBar.fillRect(GW - 70, GCY + 35, 60, 8);
-        this.spGaugeBar.fillStyle(this.spGauge >= 100 ? 0xff0000 : 0x00aaff, 1);
-        this.spGaugeBar.fillRect(GW - 70, GCY + 35, 60 * Math.min(this.spGauge / 100, 1), 8);
+        if (!this.spBtnBar) {
+            return;
+        }
+
+        var ratio = Math.min(this.spGauge / 100, 1);
+        this.spBtnBar.setScale(1, ratio);
+
+        if (ratio >= 1) {
+            this.spBtnReadyBg.setAlpha(1);
+            if (!this.spReadyTween) {
+                this.spReadyTween = this.tweens.add({
+                    targets: this.spBtnPulse,
+                    alpha: 1,
+                    duration: 400,
+                    yoyo: true,
+                    repeat: -1,
+                });
+            }
+        } else {
+            this.spBtnReadyBg.setAlpha(0);
+            this.spBtnPulse.setAlpha(0);
+            if (this.spReadyTween) {
+                this.spReadyTween.stop();
+                this.spReadyTween = null;
+            }
+        }
     }
 
     updateBossHpBar() {

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -103,6 +103,17 @@ export class PhaserTitleScene extends Phaser.Scene {
             self.titleStart();
         });
 
+        this.tapZone = this.add.zone(
+            GAME_DIMENSIONS.CENTER_X,
+            GAME_DIMENSIONS.CENTER_Y,
+            GAME_DIMENSIONS.WIDTH,
+            GAME_DIMENSIONS.HEIGHT
+        );
+        this.tapZone.setInteractive({ useHandCursor: true });
+        this.tapZone.on("pointerup", function () {
+            self.titleStart();
+        });
+
         this.fadeRect = this.add.graphics();
         this.fadeRect.fillStyle(0x000000, 1);
         this.fadeRect.fillRect(0, 0, GAME_DIMENSIONS.WIDTH, GAME_DIMENSIONS.HEIGHT);
@@ -112,8 +123,12 @@ export class PhaserTitleScene extends Phaser.Scene {
         this.startIntroAnimation();
 
         // Keyboard: Enter or Space to start
-        this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
-        this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        this.enterKey = null;
+        this.spaceKey = null;
+        try {
+            this.enterKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER);
+            this.spaceKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
+        } catch (e) {}
     }
 
     startIntroAnimation() {
@@ -273,10 +288,11 @@ export class PhaserTitleScene extends Phaser.Scene {
         }
 
         // Keyboard start
-        if (!this.transitioning) {
-            if (Phaser.Input.Keyboard.JustDown(this.enterKey) || Phaser.Input.Keyboard.JustDown(this.spaceKey)) {
-                this.titleStart();
-            }
+        if (!this.transitioning && (
+            (this.enterKey && Phaser.Input.Keyboard.JustDown(this.enterKey)) ||
+            (this.spaceKey && Phaser.Input.Keyboard.JustDown(this.spaceKey))
+        )) {
+            this.titleStart();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Make scenes tolerant of environments where keyboard input APIs may not be available to avoid runtime errors. 
- Add global tap/touch support to advance title/adv dialogue for mobile/touch users. 
- Improve loading preview and modernize UI elements (continue buttons and SP gauge) for a smoother visual experience.

### Description
- Added full-screen interactive `tapZone` to `PhaserAdvScene` and `PhaserTitleScene` to allow pointer/tap to advance dialogue or start the title.  
- Wrapped keyboard key creation in try/catch across scenes (`AdvScene`, `TitleScene`, `ContinueScene`, `GameScene`) and defaulted keys to `null` to prevent exceptions when keyboard input is unavailable, and updated `update` checks to guard against `null` keys.  
- Replaced the old loading progress bar in `BootScene` with a lightweight animated loading preview that shows `loading_bg` and cycling `loading0..2` frames, and cleaned up those preview sprites on load complete.  
- Reworked continue UI in `ContinueScene` to use sprite-based buttons, added `setupContinueButton` helper to manage pointer states and callbacks, and guarded keyboard keys similarly.  
- Refactored the SP button/gauge in `GameScene` to a container (`spBtnWrap`) composed of multiple sprites including a pulse tween when ready, replaced the previous graphics-based gauge, and updated `updateSpGauge` to animate and show readiness.  
- Fixed `createCover` to check for the correct texture/frame and avoid creating the overlay if the frame is missing.

### Testing
- Ran project linting with `npm run lint` and static checks, which completed without new warnings related to these changes.  
- Built the project with `npm run build` to ensure assets and scene code compile, and the build succeeded.  
- Executed automated unit tests with `npm test` (project test suite), and the test run passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a775bef8a88332b8bcb35f35513b52)