### PR TITLE
Fix soldier projectile path and restore 120Hz gameplay pacing

### DIFF
--- a/src/scenes/BaseScene.js
+++ b/src/scenes/BaseScene.js
@@ -23,7 +23,6 @@ export class BaseScene extends PIXI.Container {
         this.id = id;
         this.ticker = resolveTicker();
         this._accumulator = 0;
-        this._lastTickTime = 0;
         this._loop = this._onTick.bind(this);
 
         this._onSceneAdded = this._handleSceneAdded.bind(this);
@@ -33,21 +32,10 @@ export class BaseScene extends PIXI.Container {
         this.on("removed", this._onSceneRemoved);
     }
 
-    _onTick() {
-        // Fixed timestep using wall-clock time (performance.now) instead of
-        // PIXI's delta, which can be unreliable on mobile browsers / battery
-        // saver / high-refresh-rate displays.  Targets 120 logic updates/sec.
-        var now = performance.now();
-        if (this._lastTickTime === 0) {
-            this._lastTickTime = now;
-        }
-        var elapsed = now - this._lastTickTime;
-        this._lastTickTime = now;
-
-        // Convert ms to frame units (8.333ms = 1 frame at 120fps).
-        // Cap at 8 frames to handle drops down to ~15fps.
-        var FRAME_MS = 1000 / 120;
-        this._accumulator += Math.min(elapsed / FRAME_MS, 8);
+    _onTick(delta) {
+        // Keep PIXI's native delta implementation and scale to 120Hz logic.
+        // PIXI delta is normalized to 60fps, so multiply by 2.
+        this._accumulator += Math.min((delta || 0) * 2, 8);
         while (this._accumulator >= 1) {
             this._accumulator -= 1;
             this.loop(1);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -684,6 +684,8 @@ export class GameScene extends BaseScene {
 
         default: {
             const projectile = new Bullet(owner.projectileData);
+            projectile.rotX = 0;
+            projectile.rotY = 1;
             projectile.unit.x = owner.unit.x + owner.unit.width / 2 - projectile.unit.width / 2;
             projectile.unit.y = owner.unit.y + owner.unit.hitArea.height / 2;
 


### PR DESCRIPTION
### Motivation
- The game was running ~4× slower than intended due to a custom wall-clock fixed-timestep in the scene ticker and enemy bullets (soldiers) were steering toward the player instead of falling straight down.
- Restore the original PIXI ticker flow scaled to the desired 120Hz logic cadence and make default enemy projectiles travel straight down.

### Description
- Replace the wall-clock fixed-timestep in `BaseScene._onTick` with PIXI's native `delta` and scale it to 120Hz by multiplying the normalized `delta` (60Hz base) by 2 (changed `_onTick` to accept `delta` and accumulate `Math.min((delta || 0) * 2, 8)`).
- Remove the unused wall-clock state `_lastTickTime` from the `BaseScene` constructor.
- Force default enemy projectiles to downward movement by setting `projectile.rotX = 0` and `projectile.rotY = 1` in the default branch of `projectileAdd` in `src/scenes/GameScene.js` so soldier bullets no longer home on the player.

### Testing
- Ran syntax checks with `node --check src/scenes/BaseScene.js src/scenes/GameScene.js` which succeeded.
- Launched a headless verification by serving the repo with `python3 -m http.server 8000` and loading `http://127.0.0.1:8000/index.html` via Playwright to capture a runtime screenshot, which loaded successfully and produced a screenshot for manual review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e34722bc83328b52ca5f0d87f5b4)