### PR TITLE
Use PIXI delta-based fixed timestep for scenes and set default projectile direction

### DIFF
--- a/src/app-original.js
+++ b/src/app-original.js
@@ -1161,6 +1161,8 @@ import { PLAYER_STATES, BOSS_STATES } from "./enums/player-boss-states.js";
             }(this, e),
             // t is used to set the id property of the N instance
             (o = j(this, X(e).call(this))).id = t,
+            o._accumulator = 0,
+            o._tick = o.atTick.bind(o),
             o.on("added", o.atSceneAdded),
             o.on("removed", o.atSceneRemoved),
             o
@@ -1193,9 +1195,17 @@ import { PLAYER_STATES, BOSS_STATES } from "./enums/player-boss-states.js";
         e.prototype.sceneAdded = function() {
             F.dlog(this.constructor.name + ".sceneAdded() Start.");
             this.run();
-            B.Manager.game.ticker.add(this.loop, this);
+            B.Manager.game.ticker.add(this._tick, this);
             B.Manager.game.ticker.start();
             F.dlog(this.constructor.name + ".sceneAdded() End.");
+        };
+
+        e.prototype.atTick = function(t) {
+            this._accumulator += Math.min((t || 0) * 2, 8);
+            while (this._accumulator >= 1) {
+                this._accumulator -= 1;
+                this.loop(1);
+            }
         };
     
         e.prototype.atSceneRemoved = function(t) {
@@ -1203,7 +1213,7 @@ import { PLAYER_STATES, BOSS_STATES } from "./enums/player-boss-states.js";
         };
     
         e.prototype.sceneRemoved = function() {
-            for (B.Manager.game.ticker.remove(this.loop, this),
+            for (B.Manager.game.ticker.remove(this._tick, this),
                 B.Manager.game.ticker.stop(); this.children[0]; ) {
                 if ("loop"in this.children[0] && "function" == typeof this.children[0].loop) {
                     B.Manager.game.ticker.remove(this.children[0].loop, this.children[0]);
@@ -7339,6 +7349,8 @@ import { PLAYER_STATES, BOSS_STATES } from "./enums/player-boss-states.js";
                     break;
                 default:
                     var y = new S(t.projectileData);
+                    y.rotX = 0,
+                    y.rotY = 1,
                     y.unit.x = t.unit.x + t.unit.width / 2 - y.unit.width / 2,
                     y.unit.y = t.unit.y + t.unit.hitArea.height / 2,
                     y.on(S.CUSTOM_EVENT_DEAD, this.enemyRemove.bind(this, y)),

--- a/src/scenes/BaseScene.js
+++ b/src/scenes/BaseScene.js
@@ -23,7 +23,6 @@ export class BaseScene extends PIXI.Container {
         this.id = id;
         this.ticker = resolveTicker();
         this._accumulator = 0;
-        this._lastTickTime = 0;
         this._loop = this._onTick.bind(this);
 
         this._onSceneAdded = this._handleSceneAdded.bind(this);
@@ -33,21 +32,10 @@ export class BaseScene extends PIXI.Container {
         this.on("removed", this._onSceneRemoved);
     }
 
-    _onTick() {
-        // Fixed timestep using wall-clock time (performance.now) instead of
-        // PIXI's delta, which can be unreliable on mobile browsers / battery
-        // saver / high-refresh-rate displays.  Targets 120 logic updates/sec.
-        var now = performance.now();
-        if (this._lastTickTime === 0) {
-            this._lastTickTime = now;
-        }
-        var elapsed = now - this._lastTickTime;
-        this._lastTickTime = now;
-
-        // Convert ms to frame units (8.333ms = 1 frame at 120fps).
-        // Cap at 8 frames to handle drops down to ~15fps.
-        var FRAME_MS = 1000 / 120;
-        this._accumulator += Math.min(elapsed / FRAME_MS, 8);
+    _onTick(delta) {
+        // Keep PIXI's native delta implementation and scale to 120Hz logic.
+        // PIXI delta is normalized to 60fps, so multiply by 2.
+        this._accumulator += Math.min((delta || 0) * 2, 8);
         while (this._accumulator >= 1) {
             this._accumulator -= 1;
             this.loop(1);

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -684,6 +684,8 @@ export class GameScene extends BaseScene {
 
         default: {
             const projectile = new Bullet(owner.projectileData);
+            projectile.rotX = 0;
+            projectile.rotY = 1;
             projectile.unit.x = owner.unit.x + owner.unit.width / 2 - projectile.unit.width / 2;
             projectile.unit.y = owner.unit.y + owner.unit.hitArea.height / 2;
 


### PR DESCRIPTION
### Motivation

- Replace wall-clock based timestep with PIXI's normalized `delta` to make scene updates consistent with the app ticker and high-refresh-rate displays.
- Ensure newly spawned default projectiles have a deterministic initial direction to avoid undefined behavior.

### Description

- Replaced the previous performance.now-based accumulator in `BaseScene` with a delta-based `_onTick(delta)` that scales PIXI's normalized delta to 120Hz logic by multiplying by `2` and caps the accumulation to `8` frames, then drives `loop(1)` while the accumulator >= 1.
- Added `_accumulator` and bound tick handler in the app container class (`N` in `src/app-original.js`) and switched ticker registration/removal to use the bound `_tick` method instead of the raw `loop` function.
- Removed the now-unused `_lastTickTime` wall-clock code path from `BaseScene` and consolidated ticker add/start logic to use the resolved ticker instance via `resolveTicker()`.
- Set default projectile orientation for the non-special case by initializing `rotX = 0` and `rotY = 1` when creating a new `Bullet` in `GameScene` (and mirrored change in `src/app-original.js`), ensuring a consistent downward projectile direction.

### Testing

- Ran the project build with `npm run build` and it completed successfully.
- Executed the automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e34722bc83328b52ca5f0d87f5b4)