### PR TITLE
Align Phaser UI and runtime behavior with PIXI parity fixes

### DIFF
--- a/src/phaser/AdvScene.js
+++ b/src/phaser/AdvScene.js
@@ -126,7 +126,6 @@ export class PhaserAdvScene extends Phaser.Scene {
             fontSize: "16px",
             fontStyle: "bold",
             color: "#ffffff",
-            padding: { x: 10, y: 10 },
         });
 
         this.txt = this.add.text(15, GAME_DIMENSIONS.CENTER_Y + 30, "", {
@@ -142,7 +141,7 @@ export class PhaserAdvScene extends Phaser.Scene {
         this.nextBtn = this.add.text(
             GAME_DIMENSIONS.WIDTH - 20,
             GAME_DIMENSIONS.HEIGHT - 30,
-            "▶",
+            "Next▼",
             {
                 fontFamily: "sans-serif",
                 fontSize: "20px",
@@ -283,9 +282,9 @@ export class PhaserAdvScene extends Phaser.Scene {
         this.nextBtn.setVisible(true);
 
         if (this.partNum >= this.scenario[this.stageKey].part.length - 1) {
-            this.nextBtn.setText("▶▶");
+            this.nextBtn.setText("LET'S GO! ▶︎");
         } else {
-            this.nextBtn.setText("▶");
+            this.nextBtn.setText("Next▼");
         }
     }
 }

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -121,6 +121,7 @@ export class PhaserGameScene extends Phaser.Scene {
         this.bossScore = 0;
         this.bossInterval = 0;
         this.bossIntervalCnt = 0;
+        this.bossIntervalCounter = 0;
         this.bossName = "";
         this.bossStageId = stageId;
         this.bossProjCnt = 0;
@@ -136,6 +137,8 @@ export class PhaserGameScene extends Phaser.Scene {
         this.shootInterval = this.recipe.playerData.shootNormal.interval || 23;
         this.shootMode = gameState.shootMode || "normal";
         this.shootSpeed = gameState.shootSpeed || "speed_normal";
+
+        this.enemyWaveFrameCounter = 0;
 
         // Keyboard controls for PC mode
         this.cursors = null;
@@ -210,6 +213,7 @@ export class PhaserGameScene extends Phaser.Scene {
             String(this.scoreCount),
             { fontFamily: "Arial", fontSize: "12px", fontStyle: "bold", color: "#ffffff", stroke: "#000000", strokeThickness: 2 }
         );
+        this.scoreText.setOrigin(0, 0.5);
         this.scoreText.setDepth(101);
 
         this.worldBestText = this.add.text(
@@ -367,6 +371,7 @@ export class PhaserGameScene extends Phaser.Scene {
 
     startGame() {
         this.gameStarted = true;
+        this.stageBgAmountMove = 1.4;
         this.enemyWaveFlg = true;
         this.frameCnt = 0;
         this.waveCount = 0;
@@ -637,6 +642,7 @@ export class PhaserGameScene extends Phaser.Scene {
         enemy.setOrigin(0.5);
         enemy.setDepth(40);
         enemy.setData("type", "enemy");
+        enemy.setData("name", data.name || "");
         enemy.setData("hp", data.hp || 1);
         enemy.setData("maxHp", data.hp || 1);
         enemy.setData("speed", data.speed || 0.8);
@@ -705,6 +711,7 @@ export class PhaserGameScene extends Phaser.Scene {
         this.bossScore = bossData.score || 5000;
         this.bossInterval = bossData.interval || 60;
         this.bossIntervalCnt = 0;
+        this.bossIntervalCounter = 0;
         this.bossName = bossData.name || "boss";
         this.bossProjCnt = 0;
 
@@ -1136,11 +1143,17 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     update(time, delta) {
+        var frameScale = delta / (1000 / 30);
+
+        if (this.stageBg && !this.playerDead && !this.stageCleared) {
+            var bgMove = this.gameStarted ? (this.stageBgAmountMove || 1.4) : 1.4;
+            this.stageBg.tilePositionY -= bgMove * frameScale;
+        }
+
         if (!this.gameStarted) return;
         if (this.playerDead || this.stageCleared) return;
 
         // Handle keyboard input every frame
-        var frameScale = delta / (1000 / 60);
         this.handleKeyboardInput(frameScale);
 
         if (this.theWorldFlg) {
@@ -1149,7 +1162,6 @@ export class PhaserGameScene extends Phaser.Scene {
             return;
         }
 
-        this.stageBg.tilePositionY -= 0.7 * frameScale;
 
         this.shootTimer += delta;
         var interval = this.shootSpeed === "speed_high" ? this.shootInterval * 0.6 : this.shootInterval;
@@ -1189,10 +1201,11 @@ export class PhaserGameScene extends Phaser.Scene {
                 var speed = enemy.getData("speed") || 0.8;
                 enemy.y += speed * frameScale;
 
-                var shootCnt = enemy.getData("shootCnt") + 1;
+                var shootCnt = enemy.getData("shootCnt") + frameScale;
                 enemy.setData("shootCnt", shootCnt);
                 var shootInterval = enemy.getData("interval") || 300;
-                if (shootInterval > 0 && shootCnt % shootInterval === 0) {
+                if (shootInterval > 0 && shootCnt >= shootInterval) {
+                    enemy.setData("shootCnt", shootCnt - shootInterval);
                     this.enemyShoot(enemy);
                 }
             } else {
@@ -1204,8 +1217,9 @@ export class PhaserGameScene extends Phaser.Scene {
                     }
                 }
 
-                this.bossIntervalCnt++;
-                if (this.bossInterval > 0 && this.bossIntervalCnt % this.bossInterval === 0) {
+                this.bossIntervalCounter += frameScale;
+                if (this.bossInterval > 0 && this.bossIntervalCounter >= this.bossInterval) {
+                    this.bossIntervalCounter -= this.bossInterval;
                     this.bossShoot();
                 }
 
@@ -1392,10 +1406,11 @@ export class PhaserGameScene extends Phaser.Scene {
         }
 
         if (this.enemyWaveFlg) {
-            if (this.frameCnt % this.waveInterval === 0) {
+            this.enemyWaveFrameCounter += frameScale;
+            if (this.enemyWaveFrameCounter >= this.waveInterval) {
+                this.enemyWaveFrameCounter -= this.waveInterval;
                 this.enemyWave();
             }
-            this.frameCnt++;
         }
 
         if (this.bossTimerStartFlg) {
@@ -1462,12 +1477,18 @@ export class PhaserGameScene extends Phaser.Scene {
         bullet.setData("score", projData.score || 0);
         bullet.setData("spgage", projData.spgage || 0);
 
-        var dx = this.playerSprite.x - enemy.x;
-        var dy = this.playerSprite.y - enemy.y;
-        var dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        var enemyName = String(enemy.getData("name") || "").toLowerCase();
+        if (enemyName === "solidera" || enemyName === "soldiera") {
+            bullet.setData("rotX", 0);
+            bullet.setData("rotY", 1);
+        } else {
+            var dx = this.playerSprite.x - enemy.x;
+            var dy = this.playerSprite.y - enemy.y;
+            var dist = Math.sqrt(dx * dx + dy * dy) || 1;
 
-        bullet.setData("rotX", dx / dist);
-        bullet.setData("rotY", dy / dist);
+            bullet.setData("rotX", dx / dist);
+            bullet.setData("rotY", dy / dist);
+        }
 
         this.enemyBullets.push(bullet);
     }

--- a/src/phaser/PhaserGame.js
+++ b/src/phaser/PhaserGame.js
@@ -9,6 +9,19 @@ import { PhaserGameScene } from "./GameScene.js";
 import { PhaserContinueScene } from "./ContinueScene.js";
 import { PhaserEndingScene } from "./EndingScene.js";
 
+
+function detectTargetFps() {
+    var maxFps = 120;
+
+    try {
+        if (typeof window !== "undefined" && window.screen && typeof window.screen.frameRate === "number") {
+            maxFps = window.screen.frameRate >= 143 ? 144 : window.screen.frameRate >= 119 ? 120 : 60;
+        }
+    } catch (e) {}
+
+    return maxFps;
+}
+
 export function createPhaserGame() {
     // Hide old PIXI canvas, show new Phaser one
     const pixiCanvas = document.getElementById("canvas");
@@ -17,6 +30,8 @@ export function createPhaserGame() {
     if (pixiCanvas) pixiCanvas.style.display = "none";
     if (phaserContainer) phaserContainer.style.display = "flex";
 
+    const targetFps = detectTargetFps();
+
     const phaserConfig = {
         type: Phaser.AUTO,
         width: GAME_DIMENSIONS.WIDTH,
@@ -24,7 +39,7 @@ export function createPhaserGame() {
         parent: "phaser-canvas",           // ← FIXED (matches your HTML)
         backgroundColor: "#000000",
         fps: {
-            target: 60
+            target: targetFps
         },
         scale: {
             mode: Phaser.Scale.FIT,
@@ -43,7 +58,7 @@ export function createPhaserGame() {
     const game = new Phaser.Game(phaserConfig);
     globalThis.__PHASER_4_GAME__ = game;   // useful for console debugging
 
-    console.log("✅ Phaser 4 game started successfully (all scenes ready)");
+    console.log("✅ Phaser 4 game started successfully (all scenes ready)", "fps:", targetFps);
     return game;
 }
 

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -4,6 +4,7 @@ import {
     getDisplayedHighScore,
     getWorldBestLabel,
     getHighScoreSyncText,
+    getHighScoreSyncTint,
 } from "../highScoreUi.js";
 import { StaffRollPanel } from "./StaffRollPanel.js";
 
@@ -93,9 +94,9 @@ export class PhaserTitleScene extends Phaser.Scene {
                 fontFamily: "Arial",
                 fontSize: "8px",
                 fontStyle: "bold",
-                color: "#cccccc",
+                color: "#9be37f",
                 stroke: "#000000",
-                strokeThickness: 1,
+                strokeThickness: 2,
             }
         );
 
@@ -386,8 +387,11 @@ export class PhaserTitleScene extends Phaser.Scene {
         if (this.highScoreText) {
             this.highScoreText.setText(String(getDisplayedHighScore()));
         }
+
         if (this.scoreSyncLabel) {
             this.scoreSyncLabel.setText(getHighScoreSyncText());
+            var syncTint = getHighScoreSyncTint();
+            this.scoreSyncLabel.setColor("#" + syncTint.toString(16).padStart(6, "0"));
         }
 
         // Keyboard start


### PR DESCRIPTION
### Motivation

- Bring the Phaser port into pixel-for-pixel parity with the original PIXI game by fixing HUD/text styling, dialog/button copy/anchoring, projectile behavior, background motion timing, and frame-rate sensitive timing.

### Description

- Title scene: make the high-score sync label use the same green tint and stronger black stroke as PIXI and update its tint each frame from sync status; (file: `src/phaser/TitleScene.js`).
- Adv scene: remove padding that mis-anchored the name label and restore the dialogue navigation copy to `Next▼` and `LET'S GO! ▶︎` so the buttons match PIXI visuals (file: `src/phaser/AdvScene.js`).
- Game scene: start the stage background moving immediately and increase its baseline speed, set the score text origin to vertically center to match bitmap alignment, store enemy names for behavior branching, make soldierA projectiles go straight down, and convert enemy/boss/wave timers to frame-scale accumulation (using a `frameScale` baseline) so timings remain correct at higher refresh rates (file: `src/phaser/GameScene.js`).
- Engine FPS: added a small detection helper and configure Phaser `fps.target` to prefer 120 FPS (and 144 if a compatible display rate is detected) for smoother parity on high-refresh displays (file: `src/phaser/PhaserGame.js`).

### Testing

- Static syntax checks passed via `node --check` for `src/phaser/TitleScene.js`, `src/phaser/AdvScene.js`, `src/phaser/GameScene.js`, and `src/phaser/PhaserGame.js` (success).
- Launched a local static server with `python3 -m http.server 8000` and captured a Playwright screenshot of the title scene as a sanity validation (succeeded and artifact produced).
- All automated checks and the browser screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa084f2a8483328707a36a11368b10)