### PR TITLE
Add phaser-game APK Build + Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,11 +113,47 @@ jobs:
           CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.12-bin.zip
         run: cordova compile android --debug --packageType=apk
 
+      - name: Save original APK
+        run: cp cordova/platforms/android/app/build/outputs/apk/debug/*.apk ./game-original.apk
+
+      - name: Prepare Cordova www for phaser-game
+        run: |
+          rm -rf cordova/www/*
+          cp -r assets cordova/www/
+          cp -r src cordova/www/
+          cp -r icons cordova/www/ || true
+          cp manifest.json cordova/www/ || true
+          cp favicon.ico cordova/www/ || true
+          cp phaser-game.html cordova/www/
+          sed -i 's/<\/head>/<script src="cordova.js"><\/script><\/head>/' cordova/www/phaser-game.html
+
+      - name: Update config.xml for phaser-game entry point
+        run: sed -i 's|<content src="index.html" />|<content src="phaser-game.html" />|' cordova/config.xml
+
+      - name: Prepare Cordova Android (phaser-game)
+        working-directory: cordova
+        run: cordova prepare android
+
+      - name: Build Cordova Android (phaser-game APK)
+        working-directory: cordova
+        env:
+          CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.12-bin.zip
+        run: cordova compile android --debug --packageType=apk
+
+      - name: Save phaser-game APK
+        run: cp cordova/platforms/android/app/build/outputs/apk/debug/*.apk ./phaser-game.apk
+
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: game-apk
-          path: cordova/platforms/android/app/build/outputs/apk/debug/*.apk
+          path: ./game-original.apk
+
+      - name: Upload phaser-game APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: phaser-game-apk
+          path: ./phaser-game.apk
 
   web:
     needs: cordova
@@ -136,6 +172,7 @@ jobs:
           cp -r src dist/
           cp -r icons dist/ || true
           cp index.html dist/
+          cp phaser-game.html dist/
           cp manifest.json dist/ || true
           cp favicon.ico dist/ || true
           cp app-original.js dist/ || true
@@ -146,11 +183,18 @@ jobs:
           name: game-apk
           path: ./apk-tmp
 
-      - name: Copy APK to dist
+      - name: Download phaser-game APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: phaser-game-apk
+          path: ./phaser-apk-tmp
+
+      - name: Copy APKs to dist
         run: |
           cp apk-tmp/*.apk dist/game.apk
-          ls -l dist/game.apk
-          rm -rf apk-tmp
+          cp phaser-apk-tmp/*.apk dist/phaser-game.apk
+          ls -l dist/game.apk dist/phaser-game.apk
+          rm -rf apk-tmp phaser-apk-tmp
 
       - name: Create downloadable zip of built site
         run: |


### PR DESCRIPTION
This change updates the GitHub Actions deployment workflow to build two separate Android APKs from the same repository: one for the original PIXI-based game (`index.html`) and another for the new Phaser 4 port (`phaser-game.html`).

Key modifications in `.github/workflows/deploy.yml`:
1.  **Cordova Job**:
    *   Saves the first built APK as `game-original.apk`.
    *   Prepares a new `www` directory for the Phaser version, including injecting `cordova.js` into `phaser-game.html`.
    *   Updates `config.xml` to set `phaser-game.html` as the content source.
    *   Performs a second `cordova compile` to generate the Phaser APK.
    *   Uploads both `game-apk` and `phaser-game-apk` as GitHub Actions artifacts.
2.  **Web Job**:
    *   Copies `phaser-game.html` into the `dist` folder.
    *   Downloads both APK artifacts.
    *   Places them into the `dist` folder as `game.apk` and `phaser-game.apk`.

This ensures that both the original and the Phaser versions of the game are accessible via the web and downloadable as Android apps from the GitHub Pages site.

---
*PR created automatically by Jules for task [16542033551458063571](https://jules.google.com/task/16542033551458063571) started by @easierbycode*