### PR TITLE
Add Firebase level loading via URL param and play button in editor

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -52,6 +52,10 @@
                             class="px-4 py-3 bg-sky-500 hover:bg-sky-600 text-black font-medium rounded-lg text-sm">
                         📥 Load from Firebase
                     </button>
+                    <button onclick="playFirebaseLevel()"
+                            class="px-4 py-3 bg-green-500 hover:bg-green-600 text-black font-medium rounded-lg text-sm">
+                        ▶ Play Level
+                    </button>
                 </div>
             </div>
         </div>
@@ -927,6 +931,21 @@
         function loadFromFirebasePrompt() {
             const name = prompt('Enter level name to load:');
             if (name) loadFromFirebase(name);
+        }
+
+        function playFirebaseLevel() {
+            let levelName = document.getElementById('firebase-level-name').value.trim();
+            if (!levelName) {
+                alert('Enter a Firebase level name first, or save/load a level.');
+                return;
+            }
+            levelName = sanitizeLevelName(levelName);
+            const stageId = getCurrentStageId();
+            const url = `phaser-game.html?level=${encodeURIComponent(levelName)}&stage=${stageId}`;
+            const popup = window.open(url, '_blank');
+            if (!popup) {
+                alert('Popup blocked. Allow popups for this page to launch the game.');
+            }
         }
 
         // ================== URL PARAM LEVEL LOADING ==================

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -4,6 +4,54 @@ import { globals } from "../globals.js";
 
 var EDITOR_PLAY_RECIPE_KEY = "__editorPhaserRecipe__";
 var EDITOR_PLAY_STAGE_KEY = "__editorPhaserStageId__";
+var FIREBASE_LEVELS_PATH = "levels";
+
+function readLevelParam() {
+    if (typeof window === "undefined") {
+        return null;
+    }
+    try {
+        var name = new URLSearchParams(window.location.search).get("level");
+        return name ? name.replace(/[.#$/\[\]]/g, "_").trim() : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function readStageParam() {
+    if (typeof window === "undefined") {
+        return null;
+    }
+    try {
+        return new URLSearchParams(window.location.search).get("stage");
+    } catch (e) {
+        return null;
+    }
+}
+
+function fetchFirebaseLevel(levelName) {
+    if (typeof firebase === "undefined" || !firebase.database) {
+        return Promise.reject(new Error("Firebase not available"));
+    }
+
+    var db;
+    if (firebase.apps && firebase.apps.length > 0) {
+        db = firebase.database();
+    } else if (window.firebaseConfig || window.__FIREBASE_CONFIG__) {
+        firebase.initializeApp(window.firebaseConfig || window.__FIREBASE_CONFIG__);
+        db = firebase.database();
+    } else {
+        return Promise.reject(new Error("No Firebase config"));
+    }
+
+    return db.ref(FIREBASE_LEVELS_PATH + "/" + levelName).once("value").then(function (snapshot) {
+        var data = snapshot.val();
+        if (!data || !data.enemylist) {
+            return Promise.reject(new Error("Level \"" + levelName + "\" not found"));
+        }
+        return data;
+    });
+}
 
 function parseStageId(value) {
     var stageId = Number(value);
@@ -159,6 +207,49 @@ export class BootScene extends Phaser.Scene {
     }
 
     create() {
+        var self = this;
+        var levelName = readLevelParam();
+
+        if (levelName) {
+            this._loadFirebaseLevel(levelName);
+            return;
+        }
+
+        this._finishBoot();
+    }
+
+    _loadFirebaseLevel(levelName) {
+        var self = this;
+        var game = this.game;
+        var stageParam = readStageParam();
+
+        fetchFirebaseLevel(levelName).then(function (data) {
+            var baseRecipe = self.cache.json.get("recipe") || {};
+            var stageKey = data.stageKey || "stage0";
+            baseRecipe[stageKey] = { enemylist: data.enemylist };
+
+            if (data.enemyData) {
+                baseRecipe.enemyData = data.enemyData;
+            }
+
+            gameState._phaserRecipe = baseRecipe;
+
+            var stageId = stageParam != null
+                ? parseStageId(stageParam)
+                : parseStageId(stageKey.replace("stage", ""));
+            primeGameStateForStage(baseRecipe, stageId);
+
+            setTimeout(function () {
+                game.scene.stop("BootScene");
+                game.scene.start("PhaserGameScene");
+            }, 50);
+        }).catch(function (err) {
+            console.warn("Firebase level load failed:", err);
+            self._finishBoot();
+        });
+    }
+
+    _finishBoot() {
         var editorPlay = readEditorPlayRequest();
         var recipe = editorPlay && editorPlay.recipe ? editorPlay.recipe : this.cache.json.get("recipe");
         if (recipe) {


### PR DESCRIPTION
BootScene now checks for ?level=<name> URL param and fetches the level
data from Firebase RTDB before starting the game scene directly. Falls
back to normal boot flow if the fetch fails.

Level editor gets a "Play Level" button that opens phaser-game.html
with ?level=<name>&stage=<id> using the current Firebase level name.

https://claude.ai/code/session_01ApypT2M1dCtsZo3aMGKK6G