### PR TITLE
Make boss attack viewer bottom controls sticky

### DIFF
--- a/boss-attack-viewer.html
+++ b/boss-attack-viewer.html
@@ -21,6 +21,7 @@ html, body { width:100%; height:100%; overflow:hidden; background:#111; font-fam
 #boss-name { position:absolute; top:8px; left:50%; transform:translateX(-50%); font-size:20px; font-weight:bold; color:#fff; letter-spacing:2px; z-index:10; pointer-events:none; text-shadow:0 0 10px rgba(0,0,0,0.8); }
 #pattern-info { position:absolute; top:8px; right:12px; font-size:11px; color:#888; z-index:10; pointer-events:none; text-align:right; }
 #bullet-count { position:absolute; bottom:4px; right:12px; font-size:11px; color:#666; z-index:10; pointer-events:none; }
+#bottom-toolbar { position:sticky; bottom:0; z-index:20; background:#1a1a1a; box-shadow:0 -2px 10px rgba(0,0,0,0.45); }
 #pattern-bar { display:flex; justify-content:center; gap:6px; padding:8px; background:#1a1a1a; border-top:1px solid #333; flex-shrink:0; flex-wrap:wrap; }
 #pattern-bar button { background:#1a2a3a; color:#8ac; border:1px solid #345; padding:5px 12px; font-family:inherit; font-size:12px; cursor:pointer; }
 #pattern-bar button:hover { background:#2a3a4a; color:#fff; }
@@ -45,12 +46,14 @@ html, body { width:100%; height:100%; overflow:hidden; background:#111; font-fam
         <div id="pattern-info"></div>
         <div id="bullet-count"></div>
     </div>
-    <div id="pattern-bar"></div>
-    <div id="control-bar">
-        <button id="btnLoop">LOOP</button>
-        <button id="btnSpeed">SPEED 1x</button>
-        <button id="btnTrails" class="on">TRAILS</button>
-        <button id="btnReset">RESET</button>
+    <div id="bottom-toolbar">
+        <div id="pattern-bar"></div>
+        <div id="control-bar">
+            <button id="btnLoop">LOOP</button>
+            <button id="btnSpeed">SPEED 1x</button>
+            <button id="btnTrails" class="on">TRAILS</button>
+            <button id="btnReset">RESET</button>
+        </div>
     </div>
 </div>
 <script>


### PR DESCRIPTION
### Motivation
- Keep the pattern and control buttons at the bottom of the boss attack viewer visible at all times so users can access playback controls while interacting with the viewer (`boss-attack-viewer.html`).

### Description
- Added a `#bottom-toolbar` wrapper with `position: sticky; bottom: 0` and moved `#pattern-bar` and `#control-bar` into it, preserving existing button IDs and structure to avoid changing JS behavior (`boss-attack-viewer.html`).

### Testing
- Served the project with `python3 -m http.server 8000`, loaded `boss-attack-viewer.html`, captured a visual screenshot with Playwright, and verified the sticky toolbar rendered as expected (screenshot artifact saved); all automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c6bd30c8833299b985d2997f0f7a)