### PR TITLE
fix: auto-increment iOS build number for TestFlight uploads

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -87,6 +87,10 @@ jobs:
         run: |
           sed -i '' 's|<content src="index.html" />|<content src="phaser-game.html" />|' cordova/config.xml
 
+      - name: Set unique build number (CFBundleVersion)
+        run: |
+          sed -i '' "s|version=\"1.0.0\"|version=\"1.0.0\" ios-CFBundleVersion=\"1.0.${{ github.run_number }}\"|" cordova/config.xml
+
       - name: Copy hooks
         run: cp -r hooks cordova/hooks
 


### PR DESCRIPTION
TestFlight rejects uploads with duplicate CFBundleVersion. Use github.run_number to generate a unique build number (1.0.N) for each CI run while keeping the marketing version at 1.0.0.