### PR TITLE
fix: bundle ES modules with esbuild for Cordova builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,10 @@ jobs:
       - name: Save original APK
         run: cp cordova/platforms/android/app/build/outputs/apk/debug/*.apk ./game-original.apk
 
+      - name: Bundle JS modules with esbuild
+        run: |
+          npx --yes esbuild src/phaser/boot-entry.js --bundle --format=iife --outfile=lib/boot.bundle.js
+
       - name: Prepare Cordova www for phaser-game
         run: |
           rm -rf cordova/www/*
@@ -129,6 +133,9 @@ jobs:
           cp favicon.ico cordova/www/ || true
           cp phaser-game.html cordova/www/
           sed -i 's/<\/head>/<script src="cordova.js"><\/script><\/head>/' cordova/www/phaser-game.html
+
+          # Replace ES module boot script with bundled version for Cordova
+          sed -i '/<script type="module">/,/<\/script>/c\<script src="./lib/boot.bundle.js"></script>' cordova/www/phaser-game.html
 
       - name: Update config.xml for phaser-game entry point
         run: sed -i 's|<content src="index.html" />|<content src="phaser-game.html" />|' cordova/config.xml

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Copy hooks
         run: cp -r hooks cordova/hooks
 
+      # ── Bundle ES modules for Cordova (WKWebView doesn't support ES module imports) ──
+      - name: Bundle JS modules with esbuild
+        run: |
+          npx --yes esbuild src/phaser/boot-entry.js --bundle --format=iife --outfile=lib/boot.bundle.js
+
       # ── Prepare www with Phaser build ─────────────────────────────────
       - name: Prepare Cordova www (Phaser version)
         run: |
@@ -108,6 +113,10 @@ jobs:
 
           # Inject cordova.js before closing </head>
           sed -i '' 's|</head>|<script src="cordova.js"></script></head>|' cordova/www/phaser-game.html
+
+          # Replace ES module boot script with bundled version for Cordova
+          sed -i '' '/<script type="module">/,/<\/script>/c\
+          <script src="./lib/boot.bundle.js"></script>' cordova/www/phaser-game.html
 
       - name: Prepare Cordova iOS
         working-directory: cordova

--- a/phaser-game.html
+++ b/phaser-game.html
@@ -289,7 +289,10 @@
         })();
     </script>
 
-    <!-- Boot the Phaser 4 game -->
+    <!-- Boot the Phaser 4 game.
+         For local dev (npx serve), the module script works fine.
+         For Cordova builds, CI bundles src/phaser/boot-entry.js into
+         lib/boot.bundle.js and replaces this block with a regular script. -->
     <script type="module">
         import { gameState } from "./src/gameState.js";
         import { initializeFirebaseScores } from "./src/firebaseScores.js";
@@ -299,12 +302,10 @@
             return new Promise(function (resolve) { setTimeout(resolve, ms); });
         }
 
-        // ?lowmode=1 skips audio loading for faster boot (useful for testing)
         if (new URLSearchParams(window.location.search).get("lowmode") === "1") {
             gameState.lowModeFlg = true;
         }
 
-        // Initialize Firebase scores (race with timeout for fast boot)
         Promise.race([
             initializeFirebaseScores().catch(function () {}),
             waitFor(1500),

--- a/src/phaser/boot-entry.js
+++ b/src/phaser/boot-entry.js
@@ -1,0 +1,25 @@
+// Boot entry point — bundled by esbuild into a single non-module script
+// for Cordova compatibility (WKWebView may not support ES module imports).
+
+import { gameState } from "../gameState.js";
+import { initializeFirebaseScores } from "../firebaseScores.js";
+import { createPhaserGame } from "./PhaserGame.js";
+
+function waitFor(ms) {
+    return new Promise(function (resolve) { setTimeout(resolve, ms); });
+}
+
+// ?lowmode=1 skips audio loading for faster boot (useful for testing)
+try {
+    if (new URLSearchParams(window.location.search).get("lowmode") === "1") {
+        gameState.lowModeFlg = true;
+    }
+} catch (e) {}
+
+// Initialize Firebase scores (race with timeout for fast boot)
+Promise.race([
+    initializeFirebaseScores().catch(function () {}),
+    waitFor(1500),
+]).then(function () {
+    createPhaserGame();
+});


### PR DESCRIPTION
WKWebView in Cordova iOS doesn't reliably support ES module imports via <script type="module">, causing a silent black screen. CI now bundles src/phaser/boot-entry.js into lib/boot.bundle.js using esbuild and replaces the module script tag with a regular script in Cordova builds. Local dev still uses ES modules via npx serve.