### PR TITLE
fix: remove cache-busting query strings from atlas JSON meta.image

### DIFF
--- a/assets/game_asset.json
+++ b/assets/game_asset.json
@@ -3804,7 +3804,7 @@
 	"meta": {
 		"app": "",
 		"version": "1.0",
-		"image": "img/game_asset.png?t=201903150000",
+		"image": "img/game_asset.png",
 		"format": "RGBA8888",
 		"size": {
 			"w": 2048,

--- a/assets/game_ui.json
+++ b/assets/game_ui.json
@@ -2484,7 +2484,7 @@
 	"meta": {
 		"app": "",
 		"version": "1.0",
-		"image": "img/game_ui.png?t=201903150000",
+		"image": "img/game_ui.png",
 		"format": "RGBA8888",
 		"size": {
 			"w": 2048,

--- a/assets/title_ui.json
+++ b/assets/title_ui.json
@@ -284,7 +284,7 @@
 	"meta": {
 		"app": "",
 		"version": "1.0",
-		"image": "img/title_ui.png?t=201903190000",
+		"image": "img/title_ui.png",
 		"format": "RGBA8888",
 		"size": {
 			"w": 1048,


### PR DESCRIPTION
Cordova's WKURLSchemeHandler can't resolve file paths with query strings (?t=201903190000), causing atlas textures to fail loading and show green placeholder boxes on iOS.