### PR TITLE
fix: correct title_ui meta.size and add iOS debug diagnostics

### DIFF
--- a/assets/title_ui.json
+++ b/assets/title_ui.json
@@ -287,8 +287,8 @@
 		"image": "img/title_ui.png",
 		"format": "RGBA8888",
 		"size": {
-			"w": 1048,
-			"h": 2048
+			"w": 1024,
+			"h": 512
 		},
 		"scale": "1",
 		"smartupdate": "$TexturePacker:SmartUpdate:2f213a6b451f9f5719773418dfe80ae8$"

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -166,6 +166,19 @@ export class BootScene extends Phaser.Scene {
         this.load.on("filecomplete-image-loading_bg", ensureLoadingPreview);
         this.load.on("filecomplete-image-loading0", ensureLoadingPreview);
 
+        this.load.on("loaderror", function (file) {
+            console.error("LOAD ERROR:", file.key, file.type, file.src || file.url);
+            // Show visible error on screen for Cordova debugging
+            var el = document.getElementById("loadError");
+            if (!el) {
+                el = document.createElement("div");
+                el.id = "loadError";
+                el.style.cssText = "position:fixed;top:0;left:0;right:0;background:red;color:white;font:12px monospace;padding:4px;z-index:9999;max-height:30vh;overflow:auto;";
+                document.body.appendChild(el);
+            }
+            el.textContent += "ERR: " + file.key + " (" + file.type + ") " + (file.src || file.url || "") + "\n";
+        });
+
         this.load.on("complete", function () {
             if (self.loadingG) {
                 self.loadingG.destroy();
@@ -174,6 +187,21 @@ export class BootScene extends Phaser.Scene {
             if (self.loadingBg) {
                 self.loadingBg.destroy();
                 self.loadingBg = null;
+            }
+
+            // Debug: log atlas texture status
+            var atlasKeys = ["title_ui", "game_ui", "game_asset"];
+            for (var a = 0; a < atlasKeys.length; a++) {
+                var k = atlasKeys[a];
+                var tex = self.textures.exists(k) ? self.textures.get(k) : null;
+                if (tex) {
+                    var src = tex.source && tex.source[0];
+                    console.log("ATLAS " + k + ": frames=" + tex.getFrameNames().length +
+                        " img=" + (src && src.image ? src.image.width + "x" + src.image.height : "none") +
+                        " src=" + (src && src.image ? src.image.src : "none"));
+                } else {
+                    console.warn("ATLAS " + k + ": NOT FOUND in textures");
+                }
             }
         });
 

--- a/src/phaser/boot-entry.js
+++ b/src/phaser/boot-entry.js
@@ -1,6 +1,21 @@
 // Boot entry point — bundled by esbuild into a single non-module script
 // for Cordova compatibility (WKWebView may not support ES module imports).
 
+// Global error overlay for Cordova debugging
+window.onerror = function (msg, src, line, col, err) {
+    var el = document.getElementById("loadError");
+    if (!el) {
+        el = document.createElement("div");
+        el.id = "loadError";
+        el.style.cssText = "position:fixed;top:0;left:0;right:0;background:red;color:white;font:12px monospace;padding:4px;z-index:9999;max-height:30vh;overflow:auto;white-space:pre-wrap;";
+        document.body.appendChild(el);
+    }
+    el.textContent += "JS: " + msg + " @ " + src + ":" + line + "\n";
+};
+window.onunhandledrejection = function (e) {
+    console.error("Unhandled rejection:", e.reason);
+};
+
 import { gameState } from "../gameState.js";
 import { initializeFirebaseScores } from "../firebaseScores.js";
 import { createPhaserGame } from "./PhaserGame.js";


### PR DESCRIPTION
- Fix title_ui.json meta.size (was 1048x2048, actual PNG is 1024x512)
- Add visible error overlay for load failures (red banner on screen)
- Log atlas texture status after loading completes
- Add global error handler to boot-entry.js for Cordova debugging