### PR TITLE
fix: use https scheme for Cordova iOS to enable fetch() API

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -53,6 +53,11 @@
         <preference name="Orientation" value="portrait" />
         <preference name="AllowBackForwardNavigationGestures" value="false" />
         <preference name="DisallowOverscroll" value="true" />
+        <!-- Use https scheme so fetch() API works in WKWebView.
+             The default "app://" scheme doesn't route fetch() through
+             the WKURLSchemeHandler, causing all Phaser 4 asset loads to fail. -->
+        <preference name="scheme" value="https" />
+        <preference name="hostname" value="localhost" />
     </platform>
 
     <!-- Plugins removed: cordova-plugin-statusbar and cordova-plugin-vibration


### PR DESCRIPTION
Phaser 4 uses fetch() to load all assets (images, JSON, audio). Cordova iOS's default app:// scheme doesn't route fetch() through the WKURLSchemeHandler, causing every asset to fail loading silently. Switching to https://localhost scheme makes fetch() work correctly.