### PR TITLE
fix: disable Web Audio API for iOS Cordova audio compatibility

### DIFF
--- a/src/phaser/PhaserGame.js
+++ b/src/phaser/PhaserGame.js
@@ -33,6 +33,9 @@ export function createPhaserGame() {
             mode: Phaser.Scale.FIT,
             autoCenter: Phaser.Scale.CENTER_BOTH
         },
+        audio: {
+            disableWebAudio: true
+        },
         scene: [
             BootScene,
             PhaserTitleScene,


### PR DESCRIPTION
Web Audio's decodeAudioData() fails with Cordova's WKURLSchemeHandler on iOS. Switch to HTML5 Audio which handles custom URL schemes correctly.