### PR TITLE
fix: upgrade Gradle to 8.14.2 for CI compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,9 +70,9 @@ jobs:
           fi
           # Keep a known-good Gradle wrapper version for CI reproducibility.
           if grep -q "android-gradle-distribution-url" cordova/config.xml; then
-            sed -i 's|android-gradle-distribution-url" value=".*"|android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.12-bin.zip"|' cordova/config.xml
+            sed -i 's|android-gradle-distribution-url" value=".*"|android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.14.2-bin.zip"|' cordova/config.xml
           else
-            sed -i '/<\/widget>/i \    <preference name="android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.12-bin.zip" \/>' cordova/config.xml
+            sed -i '/<\/widget>/i \    <preference name="android-gradle-distribution-url" value="https://services.gradle.org/distributions/gradle-8.14.2-bin.zip" \/>' cordova/config.xml
           fi
 
       - name: Copy hooks into Cordova project
@@ -112,7 +112,7 @@ jobs:
       - name: Build Cordova Android (APK)
         working-directory: cordova
         env:
-          CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.12-bin.zip
+          CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.14.2-bin.zip
         run: cordova compile android --debug --packageType=apk
 
       - name: Save original APK
@@ -147,7 +147,7 @@ jobs:
       - name: Build Cordova Android (phaser-game APK)
         working-directory: cordova
         env:
-          CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.12-bin.zip
+          CORDOVA_ANDROID_GRADLE_DISTRIBUTION_URL: https://services.gradle.org/distributions/gradle-8.14.2-bin.zip
         run: cordova compile android --debug --packageType=apk
 
       - name: Save phaser-game APK


### PR DESCRIPTION
Gradle 8.12 wrapper generation was failing in CI. Update to 8.14.2 which is compatible with Cordova Android 14 (AGP 8.7.x).