### PR TITLE
fix: iOS Cordova audio — use HTML5 Audio + touch unlock

### DIFF
--- a/phaser-game.html
+++ b/phaser-game.html
@@ -235,6 +235,43 @@
         }
 
         // -----------------------------------------------------------------------
+        // iOS Audio unlock — create & resume AudioContext on first touch
+        // iOS suspends AudioContext until a user gesture triggers it.
+        // We also unlock HTML5 Audio by playing a silent data-URI.
+        // -----------------------------------------------------------------------
+        (function unlockAudio() {
+            function unlock() {
+                // Resume any existing AudioContext (Web Audio)
+                var AudioCtx = window.AudioContext || window.webkitAudioContext;
+                if (AudioCtx) {
+                    var ctx = new AudioCtx();
+                    if (ctx.state === "suspended") ctx.resume();
+                    var buf = ctx.createBuffer(1, 1, 22050);
+                    var src = ctx.createBufferSource();
+                    src.buffer = buf;
+                    src.connect(ctx.destination);
+                    src.start(0);
+                    ctx.close();
+                }
+                // Unlock HTML5 Audio by playing a silent mp3
+                var a = new Audio();
+                a.src = "data:audio/mpeg;base64,/+NIxAAAAAANIAAAAAExBTUUzLjEwMFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV";
+                a.play().catch(function(){});
+                // Also resume Phaser's AudioContext if it exists
+                if (window.__PHASER_4_GAME__ && window.__PHASER_4_GAME__.sound && window.__PHASER_4_GAME__.sound.context) {
+                    var gc = window.__PHASER_4_GAME__.sound.context;
+                    if (gc.state === "suspended") gc.resume();
+                }
+                document.removeEventListener("touchstart", unlock, true);
+                document.removeEventListener("touchend", unlock, true);
+                document.removeEventListener("click", unlock, true);
+            }
+            document.addEventListener("touchstart", unlock, true);
+            document.addEventListener("touchend", unlock, true);
+            document.addEventListener("click", unlock, true);
+        })();
+
+        // -----------------------------------------------------------------------
         // Edge-swipe prevention
         // -----------------------------------------------------------------------
         (function preventEdgeSwipe() {

--- a/src/phaser/PhaserGame.js
+++ b/src/phaser/PhaserGame.js
@@ -34,7 +34,7 @@ export function createPhaserGame() {
             autoCenter: Phaser.Scale.CENTER_BOTH
         },
         audio: {
-            disableWebAudio: true
+            disableWebAudio: !!window.cordova
         },
         scene: [
             BootScene,


### PR DESCRIPTION
Cordova's WKURLSchemeHandler breaks Web Audio's XHR-based audio loading. Use HTML5 Audio for Cordova builds (detected via window.cordova), keep Web Audio for web. Add touch/click unlock handler to resume suspended AudioContext and play a silent mp3 on first interaction, which is required by iOS to allow audio playback.