### PR TITLE
fix: enable audio playback in iOS Cordova build

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -59,6 +59,8 @@
              the WKURLSchemeHandler, causing all Phaser 4 asset loads to fail. -->
         <preference name="scheme" value="https" />
         <preference name="hostname" value="localhost" />
+        <preference name="MediaPlaybackRequiresUserAction" value="false" />
+        <preference name="AllowsInlineMediaPlayback" value="true" />
     </platform>
 
     <!-- Plugins removed: cordova-plugin-statusbar and cordova-plugin-vibration


### PR DESCRIPTION
## Summary
- Add `MediaPlaybackRequiresUserAction = false` to iOS platform config so WKWebView allows the Web Audio API context to start without a user gesture
- Add `AllowsInlineMediaPlayback = true` to allow inline audio/media playback

## Test plan
- [ ] Install TestFlight build and verify audio plays (BGM, SFX, voices)
- [ ] Confirm audio resumes after backgrounding/foregrounding the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)