### PR TITLE
Add Electron AppImage build to deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy (GitHub Pages + Cordova)
+name: Build & Deploy (GitHub Pages + Cordova + Electron)
 
 on:
   push:

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "2028-ai",
+  "name": "phaser-game",
   "version": "1.0.0",
   "description": "2028.ai — AI vs The World",
   "main": "main.js",
@@ -9,7 +9,7 @@
   },
   "build": {
     "appId": "com.easierbycode.game2028",
-    "productName": "2028.ai",
+    "productName": "phaser-game",
     "linux": {
       "target": "AppImage",
       "icon": "icons/icon-512.png",


### PR DESCRIPTION
## Summary
- Adds `electron/` directory with `main.js` and `package.json` for packaging the Phaser game as a Linux AppImage
- Adds `electron` job to `deploy.yml` that builds the AppImage via electron-builder
- Updates `web` job to include the AppImage in the GitHub Pages deploy as `phaser-game.AppImage`
- Fixes broken AppImage issue where `productName` with dots (e.g. `2028.ai`) caused the AppRun script to look for `/2028-ai` (non-existent absolute path)

## Test plan
- [ ] Verify CI workflow completes successfully with the new `electron` job
- [ ] Download the AppImage artifact from the CI build
- [ ] Test launching the AppImage on Bazzite desktop mode
- [ ] Test adding to Steam and launching in Gaming Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)