### PR TITLE
fix: AppImage black screen - bundle ES modules for Electron

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,10 +182,16 @@ jobs:
           mkdir -p www icons
           cp -r ../assets www/
           cp -r ../src www/
+          cp -r ../lib www/
           cp ../icons/icon-512.png icons/icon-512.png || true
           cp ../phaser-game.html www/phaser-game.html
           cp ../manifest.json www/ || true
           cp ../favicon.ico www/ || true
+
+      - name: Bundle JS modules with esbuild for Electron
+        run: |
+          npx --yes esbuild src/phaser/boot-entry.js --bundle --format=iife --outfile=electron/www/lib/boot.bundle.js
+          sed -i '/<script type="module">/,/<\/script>/c\<script src="./lib/boot.bundle.js"></script>' electron/www/phaser-game.html
 
       - name: Install Electron dependencies
         working-directory: electron


### PR DESCRIPTION
## Summary
- Copies `lib/` directory (phaser.min.js, firebase libs) into Electron `www/`
- Bundles ES module imports with esbuild (same approach as Cordova build)
- Replaces `<script type="module">` with bundled script to avoid `file://` CORS blocking

The AppImage launched but showed a black screen because Electron's `file://` protocol blocks ES module imports and the `lib/` directory with Phaser/Firebase wasn't being included.

## Test plan
- [ ] CI builds successfully
- [ ] Download AppImage and launch on Bazzite desktop — game should render (not black screen)
- [ ] Add to Steam and test in Gaming Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)