### PR TITLE
feat: restore portrait lock for Electron AppImage (Legion Go)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,32 +1,139 @@
-const { app, BrowserWindow } = require("electron");
+const { app, BrowserWindow, screen, protocol, net } = require("electron");
 const path = require("path");
+const { execSync } = require("child_process");
 
-// Enable Chromium gamepad support (required for some Linux/Steam environments)
+// ---------------------------------------------------------------------------
+// Chromium flags for gamepad / handheld support
+// ---------------------------------------------------------------------------
 app.commandLine.appendSwitch("enable-gamepad-extensions");
 app.commandLine.appendSwitch("enable-features", "WebHID,GamepadAPI");
-// Prevent Chromium from throttling gamepad polling when window loses focus
 app.commandLine.appendSwitch("disable-background-timer-throttling");
 
-function createWindow() {
-  const win = new BrowserWindow({
-    fullscreen: true,
-    autoHideMenuBar: true,
-    icon: path.join(__dirname, "icons", "icon-512.png"),
-    webPreferences: {
-      nodeIntegration: false,
-      contextIsolation: true,
+// ---------------------------------------------------------------------------
+// Clear Steam environment variables so the AppImage can launch its own
+// Chromium process without conflicting with Steam's runtime libraries.
+// ---------------------------------------------------------------------------
+var STEAM_ENV_PREFIXES = ["STEAM_", "SteamApp", "PRESSURE_VESSEL_", "LD_PRELOAD"];
+for (var key of Object.keys(process.env)) {
+    if (STEAM_ENV_PREFIXES.some(function (p) { return key.startsWith(p); })) {
+        delete process.env[key];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Custom protocol — serves www/ files with a real origin so ES module
+// imports work (file:// blocks them due to CORS).
+// ---------------------------------------------------------------------------
+protocol.registerSchemesAsPrivileged([{
+    scheme: "app",
+    privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
     },
-  });
+}]);
 
-  win.loadFile(path.join(__dirname, "www", "phaser-game.html"));
+// ---------------------------------------------------------------------------
+// Portrait rotation via xrandr (Linux only)
+// On landscape handhelds like the Legion Go the display must be rotated so
+// the fullscreen window is portrait.  We rotate before creating the window
+// and restore on exit.  When the display is already portrait (or xrandr is
+// unavailable) this is a no-op.
+// ---------------------------------------------------------------------------
+var rotated = false;
+var displayOutput = null;
 
-  win.webContents.on("did-finish-load", () => {
-    win.webContents.executeJavaScript("window.__fitCanvas && window.__fitCanvas()");
-  });
+function getDisplayOutput() {
+    try {
+        var out = execSync("xrandr --query", { timeout: 3000 }).toString();
+        var m = out.match(/^(\S+)\s+connected\s+primary/m);
+        if (m) return m[1];
+        m = out.match(/^(\S+)\s+connected/m);
+        return m ? m[1] : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function rotateToPortrait() {
+    if (process.platform !== "linux") return;
+    displayOutput = getDisplayOutput();
+    if (!displayOutput) return;
+
+    var display = screen.getPrimaryDisplay();
+    if (display.size.width > display.size.height) {
+        try {
+            execSync("xrandr --output " + displayOutput + " --rotate right",
+                { timeout: 3000 });
+            rotated = true;
+        } catch (e) {
+            // xrandr unavailable (Wayland / Gamescope) — CSS hack is the fallback
+        }
+    }
+}
+
+function restoreRotation() {
+    if (!rotated || !displayOutput) return;
+    try {
+        execSync("xrandr --output " + displayOutput + " --rotate normal",
+            { timeout: 3000 });
+    } catch (e) {}
+    rotated = false;
+}
+
+// ---------------------------------------------------------------------------
+// Window
+// ---------------------------------------------------------------------------
+function createWindow() {
+    rotateToPortrait();
+
+    // Register the custom protocol handler for www/ files
+    var wwwRoot = path.join(__dirname, "www");
+    protocol.handle("app", function (request) {
+        var filePath = decodeURIComponent(
+            new URL(request.url).pathname
+        );
+        return net.fetch("file://" + path.join(wwwRoot, filePath));
+    });
+
+    var win = new BrowserWindow({
+        fullscreen: true,
+        autoHideMenuBar: true,
+        frame: false,
+        icon: path.join(__dirname, "icons", "icon-512.png"),
+        webPreferences: {
+            nodeIntegration: false,
+            contextIsolation: true,
+        },
+    });
+
+    win.loadURL("app://game/phaser-game.html");
+
+    win.webContents.on("did-finish-load", function () {
+        // Mark <html> so the CSS rotation hack is skipped when xrandr succeeded
+        if (rotated) {
+            win.webContents.executeJavaScript(
+                "document.documentElement.classList.add('electron-rotated')"
+            );
+        }
+        // Trigger manual canvas scaling (Phaser uses Scale.NONE)
+        win.webContents.executeJavaScript(
+            "window.__fitCanvas && window.__fitCanvas()"
+        );
+    });
 }
 
 app.whenReady().then(createWindow);
 
-app.on("window-all-closed", () => {
-  app.quit();
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+app.on("will-quit", restoreRotation);
+app.on("window-all-closed", function () {
+    restoreRotation();
+    app.quit();
 });
+
+process.on("SIGINT", function () { restoreRotation(); process.exit(); });
+process.on("SIGTERM", function () { restoreRotation(); process.exit(); });

--- a/phaser-game.html
+++ b/phaser-game.html
@@ -73,6 +73,24 @@
             height: 100%;
             border: none;
         }
+        /* Force portrait layout on landscape screens (mobile web fallback).
+           Skipped when Electron has rotated the display via xrandr
+           (.electron-rotated class added by electron/main.js). */
+        @media screen and (orientation: landscape) {
+            html:not(.electron-rotated) {
+                transform: rotate(-90deg);
+                transform-origin: left top;
+                width: 100vh;
+                height: 100vw;
+                overflow: hidden;
+                position: absolute;
+                top: 100%;
+                left: 0;
+            }
+            html:not(.electron-rotated) #phaser-canvas {
+                height: 100%;
+            }
+        }
     </style>
 
     <!-- Firebase config (global, loaded before compat libs) -->


### PR DESCRIPTION
## Summary
- Restores full-screen portrait mode for the Electron AppImage build on landscape handhelds (Legion Go)
- Uses `xrandr --rotate right` to physically rotate the display to portrait before creating the fullscreen BrowserWindow, then restores on exit — this avoids CSS rotation coordinate mapping issues that break Phaser 4 input/hit testing
- CSS rotation hack in `phaser-game.html` is kept as fallback for mobile web but skipped in Electron via `.electron-rotated` class when xrandr succeeds
- Adds custom `app://` protocol in Electron so ES module imports work without CORS issues (no esbuild bundling needed at runtime)
- Includes Steam env var cleanup, gamepad flags, and `__fitCanvas` call for `Scale.NONE` compatibility
- Updates CI deploy workflow with Electron AppImage build job

## Test plan
- [ ] Verify phaser-game.html loads correctly in portrait on mobile/desktop browser
- [ ] Verify CSS rotation hack activates in landscape browser viewport
- [ ] Build AppImage and test on Legion Go in portrait orientation
- [ ] Confirm TitleScene buttons (start, howto, staffroll, twitter) respond to clicks/taps correctly
- [ ] Verify display rotation restores to normal on app exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)