### PR TITLE
fix: prevent landscape canvas overflow on Legion Go Electron build

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -111,12 +111,13 @@ function createWindow() {
     win.loadURL("app://game/phaser-game.html");
 
     win.webContents.on("did-finish-load", function () {
-        // Mark <html> so the CSS rotation hack is skipped when xrandr succeeded
-        if (rotated) {
-            win.webContents.executeJavaScript(
-                "document.documentElement.classList.add('electron-rotated')"
-            );
-        }
+        // Mark <html> as Electron so the CSS rotation hack is skipped
+        // entirely (CSS rotation breaks Phaser input/hit-testing).
+        // When xrandr succeeded, also add 'electron-rotated'.
+        var cls = "'electron'" + (rotated ? ",'electron-rotated'" : "");
+        win.webContents.executeJavaScript(
+            "document.documentElement.classList.add(" + cls + ")"
+        );
         // Trigger manual canvas scaling (Phaser uses Scale.NONE)
         win.webContents.executeJavaScript(
             "window.__fitCanvas && window.__fitCanvas()"

--- a/phaser-game.html
+++ b/phaser-game.html
@@ -73,11 +73,12 @@
             height: 100%;
             border: none;
         }
-        /* Force portrait layout on landscape screens (mobile web fallback).
-           Skipped when Electron has rotated the display via xrandr
-           (.electron-rotated class added by electron/main.js). */
+        /* Force portrait layout on landscape screens (mobile web only).
+           Skipped entirely inside Electron (.electron class) because CSS
+           rotation breaks Phaser input hit-testing.  Electron uses xrandr
+           for physical rotation instead. */
         @media screen and (orientation: landscape) {
-            html:not(.electron-rotated) {
+            html:not(.electron) {
                 transform: rotate(-90deg);
                 transform-origin: left top;
                 width: 100vh;
@@ -87,7 +88,7 @@
                 top: 100%;
                 left: 0;
             }
-            html:not(.electron-rotated) #phaser-canvas {
+            html:not(.electron) #phaser-canvas {
                 height: 100%;
             }
         }
@@ -305,8 +306,13 @@
             if (!pc) return;
             var vw = window.innerWidth;
             var vh = window.innerHeight;
-            // CSS rotation hack swaps axes in landscape — use swapped values
-            if (vw > vh) { var tmp = vw; vw = vh; vh = tmp; }
+            // When the CSS rotation hack is active (mobile web landscape
+            // fallback), the visual viewport is portrait but innerWidth/
+            // innerHeight still report landscape — swap them.
+            // Skip the swap inside Electron or when no CSS transform exists.
+            var htmlTransform = window.getComputedStyle(document.documentElement).transform;
+            var cssRotated = htmlTransform && htmlTransform !== "none";
+            if (cssRotated && vw > vh) { var tmp = vw; vw = vh; vh = tmp; }
             var scale = Math.min(vw / 256, vh / 480);
             pc.style.width = Math.floor(256 * scale) + "px";
             pc.style.height = Math.floor(480 * scale) + "px";

--- a/src/main.js
+++ b/src/main.js
@@ -66,8 +66,11 @@ if (document.fullscreenEnabled || document.webkitFullscreenEnabled) {
 export function fitCanvas() {
     var vw = window.innerWidth;
     var vh = window.innerHeight;
-    // CSS rotation hack swaps axes in landscape — use swapped values
-    if (vw > vh) { var tmp = vw; vw = vh; vh = tmp; }
+    // When the CSS rotation hack is active (mobile web landscape fallback),
+    // innerWidth/Height still report landscape — swap to match visual viewport.
+    var htmlTransform = window.getComputedStyle(document.documentElement).transform;
+    var cssRotated = htmlTransform && htmlTransform !== "none";
+    if (cssRotated && vw > vh) { var tmp = vw; vw = vh; vh = tmp; }
 
     var c = document.querySelector("#canvas canvas");
     if (c) {


### PR DESCRIPTION
The fitCanvas() axis-swap logic assumed CSS rotation was always active in landscape, but CSS rotation breaks Phaser input hit-testing and is now skipped inside Electron (.electron class).  fitCanvas now checks getComputedStyle().transform to determine if CSS rotation is actually applied before swapping axes.  This prevents the canvas from being sized to 2560px tall in a 1600px landscape viewport (top/bottom cutoff).