### PR TITLE
fix: body height 100dvh limiting rotated viewport to square

### DIFF
--- a/phaser-game.html
+++ b/phaser-game.html
@@ -87,6 +87,9 @@
                 top: 100%;
                 left: 0;
             }
+            html:not(.electron-rotated) body {
+                height: 100%;
+            }
             html:not(.electron-rotated) #phaser-canvas {
                 height: 100%;
             }


### PR DESCRIPTION
The body element had height: 100dvh (viewport height) which capped the rotated container at 1600px instead of the full 100vw (2560px).  Added body { height: 100% } override in the landscape rotation media query so the body fills the rotated html element's full height, allowing the game canvas to fill the entire rotated viewport.