### PR TITLE
fix: auto-hide audio load errors after 6.7s

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -152,6 +152,24 @@ export class BootScene extends Phaser.Scene {
             });
         }
 
+        // Auto-hide audio load errors after 6.7s
+        // Phaser may render "ERR:" text on canvas or add DOM elements
+        this.load.on("loaderror", function (file) {
+            console.warn("Load error:", file.key, file.src);
+            setTimeout(function () {
+                // Remove any Phaser-created text objects showing errors
+                if (self.children && self.children.list) {
+                    var children = self.children.list.slice();
+                    for (var e = 0; e < children.length; e++) {
+                        var child = children[e];
+                        if (child && child.type === "Text" && child.text && child.text.indexOf("ERR:") !== -1) {
+                            child.destroy();
+                        }
+                    }
+                }
+            }, 6700);
+        });
+
         this.load.on("filecomplete-image-loading_bg", ensureLoadingPreview);
         this.load.on("filecomplete-image-loading0", ensureLoadingPreview);
 


### PR DESCRIPTION
## Summary
- Add `loaderror` handler in BootScene that destroys Phaser canvas Text objects containing "ERR:" after 6700ms
- Works alongside the existing DOM-level `hideAudioErrors()` in phaser-game.html to cover both canvas-rendered and DOM-rendered error displays

## Test plan
- [ ] Deploy to TestFlight and verify audio ERR: messages disappear after ~6.7 seconds
- [ ] Confirm game loads and plays normally after errors clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)