### PR TITLE
fix: hide #loadError div after 6.7s on load complete

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -196,6 +196,14 @@ export class BootScene extends Phaser.Scene {
                 self.loadingBg = null;
             }
 
+            // Auto-hide the #loadError div after 6.7s
+            var loadErrorEl = document.getElementById("loadError");
+            if (loadErrorEl) {
+                setTimeout(function () {
+                    loadErrorEl.style.display = "none";
+                }, 6700);
+            }
+
             // Debug: log atlas texture status
             var atlasKeys = ["title_ui", "game_ui", "game_asset"];
             for (var a = 0; a < atlasKeys.length; a++) {


### PR DESCRIPTION
The previous hideAudioErrors MutationObserver approach failed because the #loadError div's textContent is updated in-place (not new child nodes), so childList mutations weren't triggered after the initial creation. Instead, hide the div directly in the loader's complete event with a 6700ms delay.