### PR TITLE
fix: use local Phaser bundle instead of CDN for boss viewers

### DIFF
--- a/boss-attack-viewer.html
+++ b/boss-attack-viewer.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Boss Attack Viewer</title>
-<script src="https://cdn.jsdelivr.net/npm/phaser@v4.0.0-rc.6/dist/phaser.min.js"></script>
+<script src="./lib/phaser.min.js"></script>
 <style>
 * { margin:0; padding:0; box-sizing:border-box; }
 html, body { width:100%; height:100%; overflow:hidden; background:#111; font-family:'Courier New',monospace; color:#ccc; }

--- a/boss-viewer.html
+++ b/boss-viewer.html
@@ -85,7 +85,7 @@
         <div id="anim-bar"></div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/phaser@4.0.0-rc.6/dist/phaser.min.js"></script>
+    <script src="./lib/phaser.min.js"></script>
     <script>
     (function() {
         var BOSS_ORDER = ["boss0","boss1","boss2","boss3","boss4","bossExtra"];


### PR DESCRIPTION
Android 9's older WebView cannot load scripts from CDN, causing boss-viewer and boss-attack-viewer to show "webpage cannot be found". Switch to the local lib/phaser.min.js bundle already used by the main game.