### PR TITLE
fix: iOS notch blocking toolbar buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,11 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            box-sizing: border-box;
+            padding-top: env(safe-area-inset-top, 0px);
+            padding-bottom: env(safe-area-inset-bottom, 0px);
+            padding-left: env(safe-area-inset-left, 0px);
+            padding-right: env(safe-area-inset-right, 0px);
         }
         #canvas canvas, #phaser-canvas canvas {
             image-rendering: pixelated;
@@ -51,7 +56,7 @@
         #iosInstallBanner {
             display: none;
             position: fixed;
-            bottom: 0;
+            bottom: env(safe-area-inset-bottom, 0px);
             left: 0;
             right: 0;
             z-index: 2000;

--- a/phaser-game.html
+++ b/phaser-game.html
@@ -35,6 +35,11 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            box-sizing: border-box;
+            padding-top: env(safe-area-inset-top, 0px);
+            padding-bottom: env(safe-area-inset-bottom, 0px);
+            padding-left: env(safe-area-inset-left, 0px);
+            padding-right: env(safe-area-inset-right, 0px);
         }
         #phaser-canvas canvas {
             image-rendering: pixelated;
@@ -44,7 +49,7 @@
         #iosInstallBanner {
             display: none;
             position: fixed;
-            bottom: 0;
+            bottom: env(safe-area-inset-bottom, 0px);
             left: 0;
             right: 0;
             z-index: 2000;

--- a/src/main.js
+++ b/src/main.js
@@ -63,9 +63,21 @@ if (document.fullscreenEnabled || document.webkitFullscreenEnabled) {
 // ---------------------------------------------------------------------------
 // Canvas FIT scaling — scales 256x480 to fill viewport, maintaining aspect ratio
 // ---------------------------------------------------------------------------
+function getContentArea(container) {
+    if (!container) return { w: window.innerWidth, h: window.innerHeight };
+    var cs = getComputedStyle(container);
+    var w = container.clientWidth
+        - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+    var h = container.clientHeight
+        - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
+    return { w: w, h: h };
+}
+
 export function fitCanvas() {
-    var vw = window.innerWidth;
-    var vh = window.innerHeight;
+    var container = document.getElementById("canvas") || document.getElementById("phaser-canvas");
+    var area = getContentArea(container);
+    var vw = area.w;
+    var vh = area.h;
     // When the CSS rotation hack is active (mobile web landscape fallback),
     // innerWidth/Height still report landscape — swap to match visual viewport.
     var htmlTransform = window.getComputedStyle(document.documentElement).transform;


### PR DESCRIPTION
## Summary
- Add `env(safe-area-inset-*)` CSS padding to game canvas containers so buttons at top (y=10) and bottom edges aren't obscured by the iOS notch/home indicator
- Update `fitCanvas()` to measure container content area (excluding safe-area padding) for correct canvas scaling
- Offset iOS install banner by bottom safe area inset

Closes #150

## Test plan
- [x] Phaser game loads without errors on desktop (mobile viewport)
- [ ] Verify on iOS device with notch that top-left/top-right buttons are clickable
- [ ] Verify bottom toolbar buttons are not cut off by home indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)