### PR TITLE
level-editor: add pixel-art CSS to match Phaser pixelArt:true rendering

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -136,7 +136,12 @@
             background: #111; color: #fff; font-size: 13px; margin-bottom: 8px;
         }
 
-        canvas { image-rendering: pixelated; }
+        /* ===== PIXEL-ART RENDERING (mimics Phaser pixelArt:true) ===== */
+        img, canvas {
+            image-rendering: pixelated;
+            image-rendering: crisp-edges;
+            -ms-interpolation-mode: nearest-neighbor;
+        }
 
         /* ===== DESKTOP TWEAKS ===== */
         @media (min-width: 768px) {


### PR DESCRIPTION
Replace the canvas-only `image-rendering: pixelated` rule with a comprehensive `img, canvas` rule that includes `crisp-edges` (Firefox) and `-ms-interpolation-mode: nearest-neighbor` fallbacks. This ensures all game object sprites in the editor render with nearest-neighbor filtering, matching how Phaser 4.0.0-rc6 displays them in-game.

https://claude.ai/code/session_01TFpRH9Ped8otjY8hyrryVs