### PR TITLE
Fix iOS audio load errors by pre-unlocking AudioContext in user gesture

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -174,10 +174,16 @@ export class BootScene extends Phaser.Scene {
             });
         }
 
+        // Track failed audio files for retry
+        var failedAudioFiles = [];
+
         // Auto-hide audio load errors after 6.7s
         // Phaser may render "ERR:" text on canvas or add DOM elements
         this.load.on("loaderror", function (file) {
             console.warn("Load error:", file.key, file.src);
+            if (file.type === "audio") {
+                failedAudioFiles.push({ key: file.key, src: file.src || file.url });
+            }
             setTimeout(function () {
                 // Remove any Phaser-created text objects showing errors
                 if (self.children && self.children.list) {
@@ -216,6 +222,25 @@ export class BootScene extends Phaser.Scene {
             if (self.loadingBg) {
                 self.loadingBg.destroy();
                 self.loadingBg = null;
+            }
+
+            // Retry failed audio files — on iOS the AudioContext may have been
+            // suspended during the first load attempt.  By the time "complete"
+            // fires, user interaction has likely unlocked it.
+            if (failedAudioFiles.length > 0) {
+                console.log("Retrying " + failedAudioFiles.length + " failed audio file(s)…");
+
+                // Ensure the AudioContext is running before retrying
+                var actx = window.__phaserAudioContext;
+                if (actx && (actx.state === "suspended" || actx.state === "interrupted")) {
+                    actx.resume().catch(function () {});
+                }
+
+                var retryFiles = failedAudioFiles.splice(0);
+                for (var r = 0; r < retryFiles.length; r++) {
+                    self.load.audio(retryFiles[r].key, retryFiles[r].src);
+                }
+                self.load.start();
             }
 
             // Auto-hide the #loadError div after 6.7s

--- a/src/phaser/PhaserGame.js
+++ b/src/phaser/PhaserGame.js
@@ -34,7 +34,8 @@ export function createPhaserGame() {
             autoCenter: Phaser.Scale.NO_CENTER
         },
         audio: {
-            disableWebAudio: false
+            disableWebAudio: false,
+            context: window.__phaserAudioContext || undefined
         },
         scene: [
             BootScene,

--- a/src/scenes/LoadScene.js
+++ b/src/scenes/LoadScene.js
@@ -253,6 +253,27 @@ export class LoadScene extends BaseScene {
             }
         }
 
+        // Pre-create and unlock an AudioContext for Phaser while still inside
+        // the user-gesture call stack.  iOS silently blocks decodeAudioData when
+        // the context is suspended, which causes every audio file to trigger a
+        // Phaser "loaderror" if the context is first created in a Promise chain.
+        var AudioCtx = window.AudioContext || window.webkitAudioContext;
+        if (AudioCtx) {
+            try {
+                var phaserCtx = new AudioCtx();
+                phaserCtx.resume();
+                // Play a tiny silent buffer to fully unlock on iOS
+                var buf = phaserCtx.createBuffer(1, 1, 22050);
+                var src = phaserCtx.createBufferSource();
+                src.buffer = buf;
+                src.connect(phaserCtx.destination);
+                src.start(0);
+                window.__phaserAudioContext = phaserCtx;
+            } catch (e) {
+                log("Could not pre-create AudioContext: " + e);
+            }
+        }
+
         this.state.lowModeFlg = false;
 
         log("Launching Phaser 4 game...");


### PR DESCRIPTION
On iOS, decodeAudioData silently fails when the AudioContext is in "suspended" state. Since Phaser is created inside a Promise chain (after loading the script), the user gesture context is lost and the AudioContext starts suspended — causing every audio file to trigger a Phaser "loaderror".

Fix:
- Pre-create and unlock an AudioContext during the user tap handler (launchPhaser), before the async Phaser load begins
- Pass the pre-unlocked context to Phaser via audio.context config
- Add retry logic in BootScene for any audio files that still fail on first attempt (belt and suspenders for edge cases)

https://claude.ai/code/session_01CqUpzxDYgsdTSEjwbe4aeV