### PR TITLE
Set default level to "2028" across all entry points

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <widget id="com.easierbycode.game2028" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>2028.ai</name>
     <description>Street Fighter browser game</description>
-    <content src="index.html" />
+    <content src="phaser-game.html?level=2028" />
 
     <access origin="*" />
     <allow-navigation href="*" />

--- a/electron/main.js
+++ b/electron/main.js
@@ -108,7 +108,7 @@ function createWindow() {
         },
     });
 
-    win.loadURL("app://game/phaser-game.html");
+    win.loadURL("app://game/phaser-game.html?level=2028");
 
     win.webContents.on("did-finish-load", function () {
         // When xrandr physically rotated the display, mark <html> so the

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -298,13 +298,8 @@ export class BootScene extends Phaser.Scene {
 
     create() {
         var self = this;
-        var levelName = readLevelParam();
-        if (levelName) {
-            this._loadFirebaseLevel(levelName);
-            return;
-        }
-
-        this._finishBoot();
+        var levelName = readLevelParam() || "2028";
+        this._loadFirebaseLevel(levelName);
     }
 
     _loadFirebaseLevel(levelName) {


### PR DESCRIPTION
## Summary
This PR establishes "2028" as the default level for the game across all application entry points (web, Cordova, and Electron), ensuring consistent behavior when no level parameter is explicitly provided.

## Key Changes
- **BootScene.js**: Simplified the `create()` method to always load a Firebase level, using "2028" as the default when no level parameter is provided via `readLevelParam()`
  - Removed conditional logic that would skip Firebase level loading
  - Changed from `readLevelParam()` check to `readLevelParam() || "2028"` pattern
  
- **config.xml**: Updated the Cordova entry point to include the default level parameter in the URL (`phaser-game.html?level=2028`)

- **electron/main.js**: Updated the Electron window load URL to include the default level parameter (`phaser-game.html?level=2028`)

## Implementation Details
The changes ensure that the game always attempts to load a level from Firebase, with "2028" serving as the fallback default. This eliminates the previous code path that would call `_finishBoot()` directly when no level parameter was detected, creating a more uniform initialization flow across all platforms.

https://claude.ai/code/session_01EVkTGgRHk49CW4KbzUPyqZ