### PR TITLE
Fix editor play requests and level-editor HTML reference

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -1270,7 +1270,7 @@
 if (!name) { name = prompt('Level name:'); if (!name) return; }
             name = sanitizeLevelName(name);
             document.getElementById('firebase-level-name').value = name;
-            window.open(`phaser-game?level=${encodeURIComponent(name)}&stage=${getCurrentStageId()}`, '_blank');
+            window.open(`phaser-game.html?level=${encodeURIComponent(name)}&stage=${getCurrentStageId()}`, '_blank');
         }
 
         // ================== AUTO-LOAD FROM SERVER ==================

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -298,6 +298,14 @@ export class BootScene extends Phaser.Scene {
 
     create() {
         var self = this;
+
+        // Editor play requests use localStorage recipe, skip Firebase
+        var editorPlay = readEditorPlayRequest();
+        if (editorPlay) {
+            this._finishBoot();
+            return;
+        }
+
         var levelName = readLevelParam() || "2028";
         this._loadFirebaseLevel(levelName);
     }


### PR DESCRIPTION
## Summary
This PR fixes two issues in the boot and level editor flow: it adds support for editor play requests using localStorage, and corrects an HTML file reference in the level editor.

## Key Changes
- **BootScene.js**: Added logic to detect and handle editor play requests via `readEditorPlayRequest()`. When an editor play request is detected, the scene skips Firebase level loading and proceeds directly to boot completion using localStorage recipe data.
- **level-editor.html**: Fixed the window.open() call to reference `phaser-game.html` instead of `phaser-game`, ensuring the correct HTML file is opened when playing a level from the editor.

## Implementation Details
The editor play request check is performed early in the `create()` method, before any Firebase operations. If detected, it bypasses the standard `_loadFirebaseLevel()` flow and calls `_finishBoot()` directly, allowing the game to use recipe data stored in localStorage instead of fetching from Firebase.

https://claude.ai/code/session_01UCj84NSyDgrbNqZaXK3736