### PR TITLE
Replace player sprite G with Cyber Liberty

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -270,6 +270,7 @@ export class BootScene extends Phaser.Scene {
         this.load.atlas("title_ui", "assets/img/title_ui.png", "assets/title_ui.json");
         this.load.atlas("game_ui", "assets/img/game_ui.png", "assets/game_ui.json");
         this.load.atlas("game_asset", "assets/img/game_asset.png", "assets/game_asset.json");
+        this.load.spritesheet("cyber-liberty", "https://easierbycode.com/assets/spritesheets/cyber-liberty.png", { frameWidth: 32, frameHeight: 32 });
 
         this.load.json("recipe", "assets/game.json");
 

--- a/src/phaser/game-objects/Bullet.js
+++ b/src/phaser/game-objects/Bullet.js
@@ -34,7 +34,7 @@ export function shootBullets(scene) {
 
     if (scene.shootMode === "3way") {
         for (var a = -1; a <= 1; a++) {
-            var b = scene.add.sprite(scene.playerSprite.x + a * 10, scene.playerSprite.y - 20, "game_asset", frameKey);
+            var b = scene.add.sprite(scene.playerSprite.x + a * 10, scene.playerSprite.y - 16, "game_asset", frameKey);
             b.setOrigin(0.5);
             b.setDepth(50);
             b.setData("damage", shootData.damage);
@@ -45,7 +45,7 @@ export function shootBullets(scene) {
             scene.playerBullets.push(b);
         }
     } else {
-        var bullet = scene.add.sprite(scene.playerSprite.x, scene.playerSprite.y - 20, "game_asset", frameKey);
+        var bullet = scene.add.sprite(scene.playerSprite.x, scene.playerSprite.y - 16, "game_asset", frameKey);
         bullet.setOrigin(0.5);
         bullet.setDepth(50);
         bullet.setData("damage", shootData.damage);

--- a/src/phaser/game-objects/Player.js
+++ b/src/phaser/game-objects/Player.js
@@ -31,10 +31,11 @@ function pointerId(pointer) {
  */
 export function createPlayer(scene) {
     var pd = scene.recipe.playerData;
-    var frames = pd.texture || [];
-    var frameKey = frames[0] || "player00.gif";
 
-    scene.playerSprite = scene.add.sprite(GCX, GH - 80, "game_asset", frameKey);
+    // Cyber Liberty: 32x32 sprite, aligned so its top matches where G's top was
+    // G was 32x64 centered at GH-80 → top at GH-112
+    // Cyber Liberty 32x32 centered at GH-96 → top at GH-112
+    scene.playerSprite = scene.add.sprite(GCX, GH - 96, "cyber-liberty", 0);
     scene.playerSprite.setOrigin(0.5);
     scene.playerSprite.setDepth(50);
 
@@ -48,30 +49,20 @@ export function createPlayer(scene) {
     scene.playerHp = gameState.playerHp || pd.maxHp;
     scene.playerMaxHp = gameState.playerMaxHp || pd.maxHp;
 
-    scene.playerAnimFrames = frames;
-    scene.playerAnimIdx = 0;
-    scene.playerAnimTimer = 0;
-
-    if (frames.length > 1) {
-        if (!scene.anims.exists("player_walk")) {
-            scene.anims.create({
-                key: "player_walk",
-                frames: scene.anims.generateFrameNames("game_asset", {
-                    prefix: "player",
-                    start: 0,
-                    end: frames.length - 1,
-                    zeroPad: 2,
-                    suffix: ".gif",
-                }),
-                frameRate: 42,
-                repeat: -1,
-            });
-        }
-        scene.playerSprite.play("player_walk");
+    if (!scene.anims.exists("cyber-liberty-idle")) {
+        scene.anims.create({
+            key: "cyber-liberty-idle",
+            frames: [
+                { key: "cyber-liberty", frame: 0, duration: 250 },
+                { key: "cyber-liberty", frame: 1, duration: 100 },
+            ],
+            repeat: -1,
+        });
     }
+    scene.playerSprite.play("cyber-liberty-idle");
 
     // PIXI player shadow: shadowOffsetY=5 (app-original.js line 589)
-    scene.playerShadow = createShadow(scene, scene.playerSprite, frameKey, true, 5);
+    scene.playerShadow = createShadow(scene, scene.playerSprite, 0, true, 5, "cyber-liberty");
     updateShadowPosition(scene.playerShadow, scene.playerSprite);
 
     scene.barrierActive = false;

--- a/src/phaser/game-objects/Shadow.js
+++ b/src/phaser/game-objects/Shadow.js
@@ -16,8 +16,8 @@
  * @param {number} shadowOffsetY              - vertical offset (pixels above shadow base)
  * @returns {Phaser.GameObjects.Sprite}
  */
-export function createShadow(scene, sprite, frameKey, shadowReverse, shadowOffsetY) {
-    var shadow = scene.add.sprite(sprite.x, sprite.y, "game_asset", frameKey);
+export function createShadow(scene, sprite, frameKey, shadowReverse, shadowOffsetY, textureKey) {
+    var shadow = scene.add.sprite(sprite.x, sprite.y, textureKey || "game_asset", frameKey);
     shadow.setOrigin(0.5);
     shadow.setTintFill(0x000000);
     shadow.setAlpha(0.5);


### PR DESCRIPTION
Swap the 32x64 player sprite for the 32x32 Cyber Liberty spritesheet loaded from external URL. Align the shorter sprite to G's original top edge (GH-96 center). Default idle animation cycles frame0 at 250ms and frame1 at 100ms. Bullet origin updated to top center of the new sprite.