### PR TITLE
Show TitleScene before game when Firebase levels load

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -381,7 +381,7 @@ export class BootScene extends Phaser.Scene {
 
                 setTimeout(function () {
                     game.scene.stop("BootScene");
-                    game.scene.start("PhaserGameScene");
+                    game.scene.start("PhaserTitleScene");
                 }, 50);
             }
 

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -375,7 +375,7 @@ export class PhaserTitleScene extends Phaser.Scene {
         gameState.maxCombo = 0;
         gameState.score = 0;
         gameState.spgage = 0;
-        gameState.stageId = 0;
+        gameState.stageId = gameState.stageId || 0;
         gameState.continueCnt = 0;
         gameState.akebonoCnt = 0;
         gameState.shortFlg = false;


### PR DESCRIPTION
Previously, successful Firebase level loads skipped TitleScene and went directly to PhaserGameScene. Now the flow goes through TitleScene so the player sees the title screen first. The Firebase stageId is preserved through the TitleScene→AdvScene transition.

https://claude.ai/code/session_018JMadoYP2Hpbm6THiiFPpJ