### PR TITLE
Fix PS2 ISO: preserve lowercase filenames for AthenaEnv

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Create PS2 ISO
         run: |
-          genisoimage -udf -o ps2.iso iso_root/
+          genisoimage -udf -l -allow-lowercase -allow-multidot -o ps2.iso iso_root/
           ls -lh ps2.iso
 
       - name: Upload PS2 ISO artifact


### PR DESCRIPTION
ISO 9660 uppercases all filenames by default, but AthenaEnv loads assets using lowercase paths (assets/game_ui.json). Add -l -allow-lowercase -allow-multidot flags to genisoimage.