### PR TITLE
Add Special Thanks section with Seamus McNamara to staff credits

### DIFF
--- a/src/phaser/StaffRollPanel.js
+++ b/src/phaser/StaffRollPanel.js
@@ -63,8 +63,8 @@ export class StaffRollPanel extends Phaser.GameObjects.Container {
         this.addLinkButton("staffrollLinkBtn.gif", 153, 329, "https://magazine.jp.square-enix.com/biggangan/introduction/highscoregirl/");
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
-        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Arial", fill: "#ffff00", align: "center" };
-        var thanksNameStyle = { fontSize: "7px", fontFamily: "Arial", fill: "#ffffff", align: "center" };
+        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Arial", fill: "#ffff00", align: "center", stroke: "#000000", strokeThickness: 2 };
+        var thanksNameStyle = { fontSize: "7px", fontFamily: "Arial", fill: "#ffffff", align: "center", stroke: "#000000", strokeThickness: 2 };
         this.thanksLabel = scene.add.text(this.GCX, 393, "SPECIAL THANKS", thanksLabelStyle);
         this.thanksLabel.setOrigin(0.5, 0);
         this.add(this.thanksLabel);

--- a/src/ui/StaffrollPanel.js
+++ b/src/ui/StaffrollPanel.js
@@ -39,13 +39,13 @@ export class StaffrollPanel extends BaseCast {
         this.addLinkButton("staffrollLinkBtn.gif", 153, 329, "https://magazine.jp.square-enix.com/biggangan/introduction/highscoregirl/");
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
-        const thanksLabel = new PIXI.Text("SPECIAL THANKS", { fontSize: 8, fontFamily: "Arial", fill: 0xffff00, align: "center" });
+        const thanksLabel = new PIXI.Text("SPECIAL THANKS", { fontSize: 8, fontFamily: "Arial", fill: 0xffff00, align: "center", stroke: 0x000000, strokeThickness: 2 });
         thanksLabel.anchor.set(0.5, 0);
         thanksLabel.x = GAME_DIMENSIONS.CENTER_X - 15;
         thanksLabel.y = 303;
         this.panel.addChild(thanksLabel);
 
-        const thanksName = new PIXI.Text("Seamus McNamara", { fontSize: 7, fontFamily: "Arial", fill: 0xffffff, align: "center" });
+        const thanksName = new PIXI.Text("Seamus McNamara", { fontSize: 7, fontFamily: "Arial", fill: 0xffffff, align: "center", stroke: 0x000000, strokeThickness: 2 });
         thanksName.anchor.set(0.5, 0);
         thanksName.x = GAME_DIMENSIONS.CENTER_X - 15;
         thanksName.y = 315;


### PR DESCRIPTION
## Summary
- Add "SPECIAL THANKS" section with "Seamus McNamara" to PS2 ending credits scroll (source + deployed build)
- Add text-based "SPECIAL THANKS" label and name to title scene staff panels (both Phaser and PIXI implementations)
- Style text with black stroke border to match existing staff roll text appearance

## Test plan
- [ ] Open title scene and tap the staff roll button — verify "SPECIAL THANKS" and "Seamus McNamara" appear below the existing credits with black bordered text
- [ ] Complete the game on PS2 build — verify "SPECIAL THANKS" and "Seamus McNamara" appear in the ending credits scroll

https://claude.ai/code/session_01H5dLEpKFk2ji8nByBYwAPH