### PR TITLE
Increase Special Thanks text resolution for sharper rendering

### DIFF
--- a/src/phaser/StaffRollPanel.js
+++ b/src/phaser/StaffRollPanel.js
@@ -63,8 +63,8 @@ export class StaffRollPanel extends Phaser.GameObjects.Container {
         this.addLinkButton("staffrollLinkBtn.gif", 153, 329, "https://magazine.jp.square-enix.com/biggangan/introduction/highscoregirl/");
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
-        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Arial", fill: "#ffff00", align: "center", stroke: "#000000", strokeThickness: 2 };
-        var thanksNameStyle = { fontSize: "7px", fontFamily: "Arial", fill: "#ffffff", align: "center", stroke: "#000000", strokeThickness: 2 };
+        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Arial", fill: "#ffff00", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
+        var thanksNameStyle = { fontSize: "7px", fontFamily: "Arial", fill: "#ffffff", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
         this.thanksLabel = scene.add.text(this.GCX, 393, "SPECIAL THANKS", thanksLabelStyle);
         this.thanksLabel.setOrigin(0.5, 0);
         this.add(this.thanksLabel);

--- a/src/ui/StaffrollPanel.js
+++ b/src/ui/StaffrollPanel.js
@@ -40,12 +40,14 @@ export class StaffrollPanel extends BaseCast {
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
         const thanksLabel = new PIXI.Text("SPECIAL THANKS", { fontSize: 8, fontFamily: "Arial", fill: 0xffff00, align: "center", stroke: 0x000000, strokeThickness: 2 });
+        thanksLabel.resolution = 4;
         thanksLabel.anchor.set(0.5, 0);
         thanksLabel.x = GAME_DIMENSIONS.CENTER_X - 15;
         thanksLabel.y = 303;
         this.panel.addChild(thanksLabel);
 
         const thanksName = new PIXI.Text("Seamus McNamara", { fontSize: 7, fontFamily: "Arial", fill: 0xffffff, align: "center", stroke: 0x000000, strokeThickness: 2 });
+        thanksName.resolution = 4;
         thanksName.anchor.set(0.5, 0);
         thanksName.x = GAME_DIMENSIONS.CENTER_X - 15;
         thanksName.y = 315;


### PR DESCRIPTION
## Summary
- Set text resolution to 4x on Special Thanks label and name in both Phaser and PIXI staff panel implementations
- Fixes blurry text rendering at small font sizes (7-8px)

## Test plan
- [ ] Open title scene staff roll — verify "SPECIAL THANKS" and "Seamus McNamara" text appears crisp and sharp

https://claude.ai/code/session_01H5dLEpKFk2ji8nByBYwAPH