### PR TITLE
Use Orbitron font and all-caps for Special Thanks text

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
     <meta name="theme-color" content="#000000" />
 
     <style>
+        @font-face {
+            font-family: 'Orbitron';
+            src: url('assets/fonts/Orbitron-Variable.woff2') format('woff2'),
+                 url('assets/fonts/Orbitron-Variable.ttf') format('truetype');
+            font-weight: 100 900;
+            font-display: swap;
+        }
         html, body {
             margin: 0;
             padding: 0;

--- a/src/phaser/StaffRollPanel.js
+++ b/src/phaser/StaffRollPanel.js
@@ -63,12 +63,12 @@ export class StaffRollPanel extends Phaser.GameObjects.Container {
         this.addLinkButton("staffrollLinkBtn.gif", 153, 329, "https://magazine.jp.square-enix.com/biggangan/introduction/highscoregirl/");
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
-        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Arial", fill: "#ffff00", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
-        var thanksNameStyle = { fontSize: "7px", fontFamily: "Arial", fill: "#ffffff", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
+        var thanksLabelStyle = { fontSize: "8px", fontFamily: "Orbitron, Arial", fill: "#ffff00", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
+        var thanksNameStyle = { fontSize: "7px", fontFamily: "Orbitron, Arial", fill: "#ffffff", align: "center", stroke: "#000000", strokeThickness: 2, resolution: 4 };
         this.thanksLabel = scene.add.text(this.GCX, 393, "SPECIAL THANKS", thanksLabelStyle);
         this.thanksLabel.setOrigin(0.5, 0);
         this.add(this.thanksLabel);
-        this.thanksName = scene.add.text(this.GCX, 405, "Seamus McNamara", thanksNameStyle);
+        this.thanksName = scene.add.text(this.GCX, 405, "SEAMUS MCNAMARA", thanksNameStyle);
         this.thanksName.setOrigin(0.5, 0);
         this.add(this.thanksName);
 

--- a/src/ui/StaffrollPanel.js
+++ b/src/ui/StaffrollPanel.js
@@ -39,14 +39,14 @@ export class StaffrollPanel extends BaseCast {
         this.addLinkButton("staffrollLinkBtn.gif", 153, 329, "https://magazine.jp.square-enix.com/biggangan/introduction/highscoregirl/");
         this.addLinkButton("staffrollLinkBtn.gif", 161, 355, "http://hi-score-girl.com/");
 
-        const thanksLabel = new PIXI.Text("SPECIAL THANKS", { fontSize: 8, fontFamily: "Arial", fill: 0xffff00, align: "center", stroke: 0x000000, strokeThickness: 2 });
+        const thanksLabel = new PIXI.Text("SPECIAL THANKS", { fontSize: 8, fontFamily: "Orbitron, Arial", fill: 0xffff00, align: "center", stroke: 0x000000, strokeThickness: 2 });
         thanksLabel.resolution = 4;
         thanksLabel.anchor.set(0.5, 0);
         thanksLabel.x = GAME_DIMENSIONS.CENTER_X - 15;
         thanksLabel.y = 303;
         this.panel.addChild(thanksLabel);
 
-        const thanksName = new PIXI.Text("Seamus McNamara", { fontSize: 7, fontFamily: "Arial", fill: 0xffffff, align: "center", stroke: 0x000000, strokeThickness: 2 });
+        const thanksName = new PIXI.Text("SEAMUS MCNAMARA", { fontSize: 7, fontFamily: "Orbitron, Arial", fill: 0xffffff, align: "center", stroke: 0x000000, strokeThickness: 2 });
         thanksName.resolution = 4;
         thanksName.anchor.set(0.5, 0);
         thanksName.x = GAME_DIMENSIONS.CENTER_X - 15;


### PR DESCRIPTION
## Summary
- Load Orbitron @font-face in index.html using existing woff2/ttf font files
- Switch Special Thanks text from Arial to Orbitron in both Phaser and PIXI staff panels
- Render name in all-caps ("SEAMUS MCNAMARA") to match staff roll style

## Test plan
- [ ] Open title scene staff roll — verify "SPECIAL THANKS" and "SEAMUS MCNAMARA" render in Orbitron font, all-caps, with black stroke

https://claude.ai/code/session_01H5dLEpKFk2ji8nByBYwAPH