### PR TITLE
Add right-click to trigger SP attack

### DIFF
--- a/src/phaser/PhaserGame.js
+++ b/src/phaser/PhaserGame.js
@@ -29,6 +29,11 @@ export function createPhaserGame() {
         fps: {
             target: 60
         },
+        input: {
+            mouse: {
+                preventDefaultRight: true   // suppress context menu for right-click SP
+            }
+        },
         scale: {
             mode: Phaser.Scale.NONE,
             autoCenter: Phaser.Scale.NO_CENTER

--- a/src/phaser/game-objects/Player.js
+++ b/src/phaser/game-objects/Player.js
@@ -90,6 +90,10 @@ export function clampPlayerX(scene, x) {
 
 export function onScreenDragStart(scene, pointer) {
     if (!scene.gameStarted || scene.playerDead) return;
+    if (pointer.rightButtonDown()) {
+        scene.onSpFire();
+        return;
+    }
     scene.playerUnitX = pointer.x;
     scene.isDragging = true;
     scene.dragPointerId = pointerId(pointer);


### PR DESCRIPTION
## Summary
- Right-clicking anywhere on the game area now triggers the SP attack (when gauge is full)
- Suppresses browser context menu on the game canvas via Phaser's `preventDefaultRight` config
- Matches existing SPACE key and SP gauge button behavior

## Test plan
- [ ] Start a game and fill the SP gauge
- [ ] Right-click on the game area — SP attack should fire
- [ ] Verify browser context menu does not appear on right-click
- [ ] Verify left-click drag still works for player movement

🤖 Generated with [Claude Code](https://claude.com/claude-code)