### PR TITLE
Skip underscore-prefixed anim keys when importing game directory

### DIFF
--- a/boss-attack-viewer.html
+++ b/boss-attack-viewer.html
@@ -651,6 +651,7 @@ html, body { width:100%; height:100%; overflow:hidden; background:#111; font-fam
             var firstFrame = null;
             if (boss.anim) {
                 for (var k in boss.anim) {
+                    if (k.startsWith("_")) continue;
                     if (boss.anim[k] && boss.anim[k].length > 0) { firstFrame = boss.anim[k][0]; break; }
                 }
             }
@@ -672,6 +673,7 @@ html, body { width:100%; height:100%; overflow:hidden; background:#111; font-fam
             var boss = bossData[bossId];
             if (!boss || !boss.anim) return;
             for (var animName in boss.anim) {
+                if (animName.startsWith("_")) continue;
                 var key = bossId + "_" + animName;
                 if (this.anims.exists(key)) continue;
                 var frameNames = boss.anim[animName];

--- a/boss-viewer.html
+++ b/boss-viewer.html
@@ -301,6 +301,7 @@
                 var firstFrame = null;
                 if (boss.anim) {
                     for (var k in boss.anim) {
+                        if (k.startsWith("_")) continue;
                         if (boss.anim[k] && boss.anim[k].length > 0) {
                             firstFrame = boss.anim[k][0];
                             break;
@@ -356,6 +357,7 @@
                 if (!boss || !boss.anim) return;
 
                 for (var animName in boss.anim) {
+                    if (animName.startsWith("_")) continue;
                     var animKey = bossId + "_" + animName;
                     if (this.anims.exists(animKey)) continue;
 
@@ -422,6 +424,7 @@
             if (!boss || !boss.anim) return;
 
             for (var animName in boss.anim) {
+                if (animName.startsWith("_")) continue;
                 (function(name) {
                     var btn = document.createElement("button");
                     btn.className = "anim-btn";

--- a/level-editor.html
+++ b/level-editor.html
@@ -764,7 +764,7 @@
             }
             for (const b of Object.values(bossData)) {
                 if (!b) continue;
-                if (b.anim) { for (const animFrames of Object.values(b.anim)) collectTextures(animFrames); }
+                if (b.anim) { for (const [k, animFrames] of Object.entries(b.anim)) { if (!k.startsWith('_')) collectTextures(animFrames); } }
                 if (b.bulletData) collectTextures(b.bulletData.texture);
             }
 


### PR DESCRIPTION
Ignore boss.anim keys starting with '_' in level-editor, boss-viewer,
and boss-attack-viewer so they are not registered as Phaser animations
or shown as UI buttons.

https://claude.ai/code/session_014fRJH63y3rjr1AYyD1jCwC