### PR TITLE
Save bossData to Firebase when saving custom levels

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -747,9 +747,30 @@
             checkMissingTextures();
         }
 
-        function checkMissingTextures() {
+        async function checkMissingTextures() {
             if (!atlasData || !atlasData.frames) return;
-            const frames = atlasData.frames;
+            const frames = Object.assign({}, atlasData.frames);
+
+            // Also load game_ui and game_asset atlases from root for cross-atlas verification
+            for (const altKey of ['game_ui', 'game_asset']) {
+                if (ATLAS_CONFIGS[altKey] && altKey !== currentAtlasKey) {
+                    try {
+                        let altJson;
+                        if (dirHandle) {
+                            const ad = await dirHandle.getDirectoryHandle(ATLAS_DIR);
+                            altJson = JSON.parse(await (await (await ad.getFileHandle(ATLAS_CONFIGS[altKey].json)).getFile()).text());
+                        } else {
+                            const resp = await fetch('assets/' + ATLAS_CONFIGS[altKey].json);
+                            if (resp.ok) altJson = await resp.json();
+                        }
+                        if (altJson) {
+                            const norm = normalizeAtlasData(altJson);
+                            if (norm && norm.frames) Object.assign(frames, norm.frames);
+                        }
+                    } catch (e) { /* alt atlas not available, skip */ }
+                }
+            }
+
             const missing = new Set();
 
             function collectTextures(texArr) {
@@ -1563,6 +1584,23 @@
                     }
                 }
             }
+            // Boss textures
+            for (const k of Object.keys(bossData)) {
+                const b = bossData[k];
+                if (b && b.anim) {
+                    for (const [ak, animFrames] of Object.entries(b.anim)) {
+                        if (ak.startsWith('_') || !Array.isArray(animFrames)) continue;
+                        for (const tex of animFrames) {
+                            if (tex && frameThumbs[tex]) thumbs[fbKeyEncode(tex)] = frameThumbs[tex].toDataURL('image/png');
+                        }
+                    }
+                }
+                if (b && b.bulletData && b.bulletData.texture) {
+                    for (const tex of b.bulletData.texture) {
+                        if (tex && frameThumbs[tex]) thumbs[fbKeyEncode(tex)] = frameThumbs[tex].toDataURL('image/png');
+                    }
+                }
+            }
             // Powerup frames
             for (const pt of POWERUP_TYPES) {
                 if (pt.frame && frameThumbs[pt.frame]) thumbs[fbKeyEncode(pt.frame)] = frameThumbs[pt.frame].toDataURL('image/png');
@@ -1606,7 +1644,7 @@
             try {
                 const payload = {
                     name, stageKey: currentStageKey, enemylist: normalizeGrid(currentGrid),
-                    enemyData: enemyData || {}, width: 8, savedAt: firebase.database.ServerValue.TIMESTAMP
+                    enemyData: enemyData || {}, bossData: bossData || {}, width: 8, savedAt: firebase.database.ServerValue.TIMESTAMP
                 };
                 const thumbs = buildFrameThumbnailsForSave();
                 if (thumbs) payload.frameThumbnails = thumbs;
@@ -1638,6 +1676,7 @@
                 if (!d) { alert(`"${name}" not found`); return false; }
                 currentGrid = normalizeGrid(d.enemylist || []);
                 if (d.enemyData && typeof d.enemyData === 'object') enemyData = d.enemyData;
+                if (d.bossData && typeof d.bossData === 'object') bossData = d.bossData;
                 if (d.stageKey) currentStageKey = d.stageKey;
                 document.getElementById('firebase-level-name').value = name;
                 document.getElementById('status').innerHTML = `<span style="color:#f59e0b">Firebase: ${name}</span>`;

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -378,6 +378,45 @@ export class BootScene extends Phaser.Scene {
                     baseRecipe.enemyData = merged;
                 }
 
+                if (data.bossData) {
+                    // Merge Firebase boss data, keeping local anim textures when
+                    // Firebase textures don't exist in the loaded atlas
+                    var mergedBoss = JSON.parse(JSON.stringify(data.bossData));
+                    var localBossData = baseRecipe.bossData ? JSON.parse(JSON.stringify(baseRecipe.bossData)) : {};
+                    try {
+                        var bossAtlas = self.textures.get("game_asset");
+                        var bossAtlasFrames = bossAtlas && bossAtlas.frames ? bossAtlas.frames : null;
+                        if (bossAtlasFrames) {
+                            for (var bk in mergedBoss) {
+                                var fb = mergedBoss[bk];
+                                var lb = localBossData[bk];
+                                if (fb && fb.anim) {
+                                    for (var ak in fb.anim) {
+                                        if (ak.startsWith('_')) continue;
+                                        var fbAnim = fb.anim[ak];
+                                        if (Array.isArray(fbAnim) && fbAnim.length > 0 && !bossAtlasFrames[fbAnim[0]]) {
+                                            if (lb && lb.anim && lb.anim[ak]) {
+                                                fb.anim[ak] = lb.anim[ak];
+                                            }
+                                        }
+                                    }
+                                }
+                                if (fb && fb.bulletData && fb.bulletData.texture) {
+                                    var fbBulletTex = fb.bulletData.texture;
+                                    if (fbBulletTex.length > 0 && !bossAtlasFrames[fbBulletTex[0]]) {
+                                        if (lb && lb.bulletData && lb.bulletData.texture) {
+                                            fb.bulletData.texture = lb.bulletData.texture;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } catch (bossTexErr) {
+                        console.warn("Boss texture resolution failed, using Firebase boss data as-is:", bossTexErr);
+                    }
+                    baseRecipe.bossData = mergedBoss;
+                }
+
                 gameState._phaserRecipe = baseRecipe;
 
                 var stageId = stageParam != null

--- a/src/ps2/main.js
+++ b/src/ps2/main.js
@@ -182,6 +182,25 @@ function loadFirebaseLevel(recipe, levelPath) {
         console.log("[Main] Firebase enemyData merged (level_atlas)");
     }
 
+    // Merge bossData: use Firebase values, tag textures with level_atlas
+    if (data.bossData) {
+        var mergedBoss = JSON.parse(JSON.stringify(data.bossData));
+
+        for (var bk in mergedBoss) {
+            var boss = mergedBoss[bk];
+            if (boss && boss.anim) {
+                boss.atlas = "level_atlas";
+            }
+            var bossProjKey = boss && boss.bulletData ? "bulletData" : null;
+            if (bossProjKey && boss[bossProjKey]) {
+                boss[bossProjKey].atlas = "level_atlas";
+            }
+        }
+
+        recipe.bossData = mergedBoss;
+        console.log("[Main] Firebase bossData merged (level_atlas)");
+    }
+
     // Parse stageId from stageKey and set in gameState
     var stageId = parseInt(stageKey.replace("stage", ""), 10);
     if (isNaN(stageId) || stageId < 0) stageId = 0;


### PR DESCRIPTION
Previously only enemyData was saved to Firebase custom levels, so bosses
always fell back to stock definitions. Now bossData is included in the
Firebase payload, restored on load, and merged with texture fallback in
both BootScene (Phaser) and PS2 port. Also verifies boss/enemy textures
against both game_asset and game_ui atlases during missing-texture check.

https://claude.ai/code/session_01NXVYwWZagNmPVjc7Y7H6p4