### PR TITLE
Fix bossData not syncing to Firebase on save

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -1931,12 +1931,20 @@
 
         // ================== SAVE ==================
         function quickSave() {
-            if (dirHandle && gameData) saveAll();
-            else saveToFirebase();
+            if (dirHandle && gameData) {
+                saveAll();
+                // Also save to Firebase if a cloud game name is set
+                var fbName = document.getElementById('firebase-level-name').value.trim();
+                if (fbName) saveToFirebase();
+            } else {
+                saveToFirebase();
+            }
         }
 
         async function saveAll() {
             if (!dirHandle || !gameData) { alert("Load directory first"); return; }
+            // Sync any pending editor form changes into gameData before saving
+            syncEnemyEditorForm();
             gameData[currentStageKey] = gameData[currentStageKey] || {};
             gameData[currentStageKey].enemylist = normalizeGrid(currentGrid);
             try {
@@ -2607,6 +2615,8 @@
         }
 
         async function saveToFirebase() {
+            // Sync any pending editor form changes into bossData/enemyData before saving
+            syncEnemyEditorForm();
             initFirebase();
             if (!firebaseDb) { alert('Firebase not available'); return; }
             let name = document.getElementById('firebase-level-name').value.trim();


### PR DESCRIPTION
Two issues caused bossData edits to not persist to Firebase:

1. saveToFirebase() and saveAll() didn't call syncEnemyEditorForm()
   before building the payload, so pending editor form changes were
   lost when saving.

2. quickSave() (Ctrl+S / toolbar button) only saved locally when
   dirHandle was set, never updating Firebase. Now it also saves to
   Firebase when a cloud game name is set.

https://claude.ai/code/session_0168cj2bxBmPnHJHdLxU4CKR