### PR TITLE
Add cloud persistence for enemy/boss saves to Firebase

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -1735,7 +1735,23 @@
         }
 
         function saveCurrentEnemy() {
-            if (syncEnemyEditorForm(true)) alert(currentEditorTab === 'bosses' ? 'Boss saved' : 'Enemy saved');
+            if (syncEnemyEditorForm(true)) {
+                const isBoss = currentEditorTab === 'bosses';
+                // Persist to Firebase RTDB if a cloud game name is set
+                const fbName = document.getElementById('firebase-level-name').value.trim();
+                if (fbName) {
+                    initFirebase();
+                    if (firebaseDb) {
+                        const dataKey = isBoss ? 'bossData' : 'enemyData';
+                        const dataVal = isBoss ? (bossData || {}) : (enemyData || {});
+                        firebaseDb.ref(`${FIREBASE_LEVELS_PATH}/${fbName}/${dataKey}`).set(dataVal)
+                            .then(() => alert((isBoss ? 'Boss' : 'Enemy') + ' saved to cloud!'))
+                            .catch(e => alert((isBoss ? 'Boss' : 'Enemy') + ' saved locally but cloud save failed: ' + e.message));
+                        return;
+                    }
+                }
+                alert(isBoss ? 'Boss saved' : 'Enemy saved');
+            }
         }
 
         // ================== ATLAS ==================


### PR DESCRIPTION
## Summary
Enhanced the enemy and boss save functionality to persist data to Firebase Realtime Database when a cloud game name is configured, while maintaining local save as a fallback.

## Key Changes
- Modified `saveCurrentEnemy()` function to check for a configured Firebase level name before saving
- Added Firebase persistence logic that:
  - Initializes Firebase connection if needed
  - Saves `bossData` or `enemyData` to the appropriate Firebase path based on editor tab
  - Provides user feedback on successful cloud saves or local-only saves with error details
  - Falls back to local-only save if no cloud name is set or Firebase is unavailable
- Improved user messaging to distinguish between local saves and cloud saves with error handling

## Implementation Details
- Uses the existing `FIREBASE_LEVELS_PATH` constant and Firebase database reference
- Determines save type (boss vs enemy) from `currentEditorTab` to route to correct data structure
- Implements promise-based error handling with user-friendly error messages
- Maintains backward compatibility by defaulting to local save when cloud is not configured

https://claude.ai/code/session_01J2m3J1hrNa1VxEq65T1QhL