### PR TITLE
Original stage bgs, audio URL support, BGM continuity

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -326,8 +326,19 @@
             font-family: 'Orbitron', sans-serif; border: 1px solid #475569;
             transition: background 0.15s;
         }
-        .audio-btn-upload { background: #1e293b; color: #94a3b8; }
+        .audio-btn-upload { background: #1e293b; color: #94a3b8; min-width: 28px; }
         .audio-btn-upload:hover { background: #334155; color: #e2e8f0; }
+        .audio-url-row { display: flex; gap: 3px; align-items: center; margin-top: 3px; }
+        .audio-url-input {
+            flex: 1; min-width: 0; background: #0f172a; color: #e2e8f0; border: 1px solid #475569;
+            border-radius: 4px; padding: 2px 5px; font-size: 9px; font-family: monospace;
+            outline: none;
+        }
+        .audio-url-input::placeholder { color: #475569; }
+        .audio-url-input:focus { border-color: #60a5fa; }
+        .audio-btn-url { background: #1e293b; color: #60a5fa; min-width: 22px; font-size: 10px; }
+        .audio-btn-url:hover { background: #334155; color: #93c5fd; }
+        .audio-slot-badge.url { background: #1e3a5f; color: #60a5fa; }
         .audio-btn-play { background: #1e293b; color: #94a3b8; border: 1px solid #475569; }
         .audio-btn-play:hover { background: #334155; color: #e2e8f0; }
         .audio-btn-reset { background: #1c0a0a; color: #f87171; border: 1px solid #7f1d1d; }
@@ -2530,6 +2541,10 @@
                     storyData: (gameData && gameData.storyData) || null,
                     width: 8, savedAt: firebase.database.ServerValue.TIMESTAMP
                 };
+                // Save audio URL overrides
+                var urlEntries = {};
+                for (var ak in audioURLs) { if (audioURLs[ak]) urlEntries[ak] = audioURLs[ak]; }
+                if (Object.keys(urlEntries).length > 0) payload.customAudioURLs = urlEntries;
                 const thumbs = buildFrameThumbnailsForSave();
                 if (thumbs) payload.frameThumbnails = thumbs;
                 if (titleBgDataURL) payload.titleBgDataURL = titleBgDataURL;
@@ -2590,6 +2605,7 @@
                 logoDataURL = d.logoDataURL || null;
                 subTitleDataURL = d.subTitleDataURL || null;
                 titleStartTextDataURL = d.titleStartTextDataURL || null;
+                audioURLs = (d.customAudioURLs && typeof d.customAudioURLs === 'object') ? d.customAudioURLs : {};
                 // Restore atlas image + frame data so re-saving doesn't lose custom sprites
                 if (d.atlasImageDataURL && d.atlasFrames) {
                     const decodedFrames = {};
@@ -2903,6 +2919,7 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
 
         let audioFilterCat = 'all';
         let audioCustomKeys = new Set();
+        let audioURLs = {};
         let audioPreviewEl = null;
 
         function setAudioFilter(cat) {
@@ -2957,18 +2974,20 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
                 catLabel.textContent = cat.toUpperCase();
                 slot.appendChild(catLabel);
 
+                const hasURL = !!audioURLs[key];
                 const badge = document.createElement('div');
-                badge.className = 'audio-slot-badge ' + (isCustom ? 'custom' : 'default');
-                badge.textContent = isCustom ? 'Custom \u2713' : 'Default';
+                badge.className = 'audio-slot-badge ' + (hasURL ? 'url' : (isCustom ? 'custom' : 'default'));
+                badge.textContent = hasURL ? 'URL' : (isCustom ? 'Custom \u2713' : 'Default');
                 slot.appendChild(badge);
 
                 const actions = document.createElement('div');
                 actions.className = 'audio-slot-actions';
 
-                // Upload button
+                // Upload icon button
                 const uploadLabel = document.createElement('label');
                 uploadLabel.className = 'audio-btn-upload';
-                uploadLabel.textContent = 'Upload';
+                uploadLabel.textContent = '\uD83D\uDCC1';
+                uploadLabel.title = 'Upload MP3 file';
                 const fileInput = document.createElement('input');
                 fileInput.type = 'file';
                 fileInput.accept = 'audio/mpeg,audio/mp3,.mp3';
@@ -2985,13 +3004,13 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
                 const playBtn = document.createElement('button');
                 playBtn.className = 'audio-btn-play';
                 playBtn.textContent = '\u25B6 Play';
-                (function(capturedKey, capturedCustom) {
-                    playBtn.onclick = function() { previewAudio(capturedKey, capturedCustom); };
-                })(key, isCustom);
+                (function(capturedKey, capturedCustom, capturedHasURL) {
+                    playBtn.onclick = function() { previewAudio(capturedKey, capturedCustom || capturedHasURL); };
+                })(key, isCustom, hasURL);
                 actions.appendChild(playBtn);
 
-                // Reset button (only for custom)
-                if (isCustom) {
+                // Reset button (only for custom or URL)
+                if (isCustom || hasURL) {
                     const resetBtn = document.createElement('button');
                     resetBtn.className = 'audio-btn-reset';
                     resetBtn.textContent = 'Reset';
@@ -3001,6 +3020,34 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
                     actions.appendChild(resetBtn);
                 }
 
+                // URL input row
+                const urlRow = document.createElement('div');
+                urlRow.className = 'audio-url-row';
+                const urlInput = document.createElement('input');
+                urlInput.type = 'text';
+                urlInput.className = 'audio-url-input';
+                urlInput.placeholder = 'https://...';
+                urlInput.value = audioURLs[key] || '';
+                const urlBtn = document.createElement('button');
+                urlBtn.className = 'audio-btn-url';
+                urlBtn.textContent = '\u2197';
+                urlBtn.title = 'Load from URL';
+                (function(capturedKey, capturedInput) {
+                    urlBtn.onclick = function() {
+                        var url = capturedInput.value.trim();
+                        if (url) handleAudioURL(capturedKey, url);
+                    };
+                    capturedInput.onkeydown = function(e) {
+                        if (e.key === 'Enter') {
+                            var url = capturedInput.value.trim();
+                            if (url) handleAudioURL(capturedKey, url);
+                        }
+                    };
+                })(key, urlInput);
+                urlRow.appendChild(urlInput);
+                urlRow.appendChild(urlBtn);
+                actions.appendChild(urlRow);
+
                 slot.appendChild(actions);
                 grid.appendChild(slot);
             }
@@ -3009,6 +3056,7 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
         function handleAudioUpload(key, file) {
             saveCustomAudio(key, file).then(function() {
                 audioCustomKeys.add(key);
+                delete audioURLs[key];
                 renderAudioEditor();
             }).catch(function(err) {
                 console.error('Failed to save custom audio:', err);
@@ -3016,7 +3064,26 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
             });
         }
 
+        function handleAudioURL(key, url) {
+            // Store URL for Firebase save, and fetch blob for local preview/IndexedDB
+            audioURLs[key] = url;
+            fetch(url).then(function(resp) {
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                return resp.blob();
+            }).then(function(blob) {
+                return saveCustomAudio(key, blob);
+            }).then(function() {
+                audioCustomKeys.add(key);
+                renderAudioEditor();
+            }).catch(function(err) {
+                console.warn('Could not fetch audio URL for preview cache:', err);
+                // URL is still saved for Firebase even if fetch fails (CORS etc.)
+                renderAudioEditor();
+            });
+        }
+
         function resetCustomAudio(key) {
+            delete audioURLs[key];
             deleteCustomAudio(key).then(function() {
                 audioCustomKeys.delete(key);
                 renderAudioEditor();
@@ -3027,6 +3094,7 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
 
         function clearAllCustomAudioUI() {
             if (!confirm('Remove all custom audio overrides?')) return;
+            audioURLs = {};
             clearAllCustomAudio().then(function() {
                 audioCustomKeys.clear();
                 renderAudioEditor();

--- a/src/phaser/AdvScene.js
+++ b/src/phaser/AdvScene.js
@@ -131,7 +131,9 @@ export class PhaserAdvScene extends Phaser.Scene {
             }
         }
 
-        this.playBgm("adventure_bgm", 0.2);
+        if (!gameState.bgmContinuityActive) {
+            this.playBgm("adventure_bgm", 0.2);
+        }
 
         var bgKey = "advBg" + this.scenario[this.stageKey].part[this.partNum].background + ".gif";
         this.bgSprite = this.add.sprite(0, 0, "game_ui", bgKey);
@@ -300,7 +302,9 @@ export class PhaserAdvScene extends Phaser.Scene {
 
     goToNextScene() {
         this.playSound("se_correct", 0.9);
-        this.stopSound("adventure_bgm");
+        if (!gameState.bgmContinuityActive) {
+            this.stopSound("adventure_bgm");
+        }
 
         var nextScene = this.endingFlg ? "PhaserEndingScene" : "PhaserGameScene";
         var game = this.game;

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -324,14 +324,20 @@ export class BootScene extends Phaser.Scene {
         this.load.json("recipe", "assets/game.json");
 
         this.load.image("title_bg", "assets/img/title_bg.jpg");
-        var stageLoopPaths = [
+        // Original per-stage backgrounds
+        for (var i = 0; i < 5; i++) {
+            this.load.image("stage_loop" + i, "assets/img/stage/stage_loop" + i + ".png");
+            this.load.image("stage_end" + i, "assets/img/stage/stage_end" + i + ".png");
+        }
+        // Custom-enemy backgrounds (stages 0-3 share bg 3, stage 4 uses bg 4)
+        var customLoopPaths = [
             "assets/img/stage/stage_loop3.png",
             "assets/img/stage/stage_loop3.png",
             "assets/img/stage/stage_loop3.png",
             "assets/img/stage/stage_loop3.png",
             "assets/img/stage/stage_loop4.png",
         ];
-        var stageEndPaths = [
+        var customEndPaths = [
             "assets/img/stage/stage_end3.png",
             "assets/img/stage/stage_end3.png",
             "assets/img/stage/stage_end3.png",
@@ -339,8 +345,8 @@ export class BootScene extends Phaser.Scene {
             "assets/img/stage/stage_end4.png",
         ];
         for (var i = 0; i < 5; i++) {
-            this.load.image("stage_loop" + i, stageLoopPaths[i]);
-            this.load.image("stage_end" + i, stageEndPaths[i]);
+            this.load.image("stage_loop_c" + i, customLoopPaths[i]);
+            this.load.image("stage_end_c" + i, customEndPaths[i]);
         }
 
         this.load.image("loading_bg", "assets/img/loading/loading_bg.png");
@@ -516,6 +522,7 @@ export class BootScene extends Phaser.Scene {
                 }
 
                 gameState._phaserRecipe = baseRecipe;
+                gameState.hasCustomEnemies = !!data.enemyData;
 
                 var stageId = stageParam != null
                     ? parseStageId(stageParam)
@@ -525,12 +532,40 @@ export class BootScene extends Phaser.Scene {
                     gameState.shortFlg = true;
                 }
 
+                // Load audio URL overrides from Firebase level data
+                if (data.customAudioURLs && typeof data.customAudioURLs === "object") {
+                    gameState.bgmSourceURLs = {};
+                    var urlKeys = Object.keys(data.customAudioURLs);
+                    for (var ui = 0; ui < urlKeys.length; ui++) {
+                        var uKey = urlKeys[ui];
+                        var uUrl = data.customAudioURLs[uKey];
+                        if (uUrl && typeof uUrl === "string") {
+                            gameState.bgmSourceURLs[uKey] = uUrl;
+                            if (self.cache.audio.exists(uKey)) {
+                                self.cache.audio.remove(uKey);
+                            }
+                            self.load.audio(uKey, uUrl);
+                        }
+                    }
+                }
+
                 var nextScene = showTitle ? "PhaserTitleScene" : "PhaserGameScene";
                 self._loadCustomAudio(function () {
-                    setTimeout(function () {
-                        game.scene.stop("BootScene");
-                        game.scene.start(nextScene);
-                    }, 50);
+                    // Start any queued URL audio loads, then transition
+                    if (gameState.bgmSourceURLs && Object.keys(gameState.bgmSourceURLs).length > 0) {
+                        self.load.once("complete", function () {
+                            setTimeout(function () {
+                                game.scene.stop("BootScene");
+                                game.scene.start(nextScene);
+                            }, 50);
+                        });
+                        self.load.start();
+                    } else {
+                        setTimeout(function () {
+                            game.scene.stop("BootScene");
+                            game.scene.start(nextScene);
+                        }, 50);
+                    }
                 });
             }
 
@@ -603,6 +638,18 @@ export class BootScene extends Phaser.Scene {
         var recipe = editorPlay && editorPlay.recipe ? editorPlay.recipe : this.cache.json.get("recipe");
         if (recipe) {
             gameState._phaserRecipe = recipe;
+        }
+
+        // Detect custom enemies by comparing against base game.json
+        var baseRecipe = this.cache.json.get("recipe");
+        if (recipe && baseRecipe && recipe.enemyData && baseRecipe.enemyData) {
+            try {
+                gameState.hasCustomEnemies = JSON.stringify(recipe.enemyData) !== JSON.stringify(baseRecipe.enemyData);
+            } catch (e) {
+                gameState.hasCustomEnemies = false;
+            }
+        } else {
+            gameState.hasCustomEnemies = false;
         }
 
         var stageParam = readStageParam();

--- a/src/phaser/ContinueScene.js
+++ b/src/phaser/ContinueScene.js
@@ -385,6 +385,8 @@ export class PhaserContinueScene extends Phaser.Scene {
         }
 
         gameState.secondLoop = true;
+        gameState.bgmContinuityActive = false;
+        gameState.currentBgmKey = null;
 
         this.stopAllSounds();
         var game = this.game;
@@ -395,6 +397,8 @@ export class PhaserContinueScene extends Phaser.Scene {
     }
 
     goNext() {
+        gameState.bgmContinuityActive = false;
+        gameState.currentBgmKey = null;
         var self = this;
         this.tweens.add({
             targets: this.cameras.main,

--- a/src/phaser/EndingScene.js
+++ b/src/phaser/EndingScene.js
@@ -199,6 +199,8 @@ export class PhaserEndingScene extends Phaser.Scene {
             self.gotoTitleBtn.disableInteractive();
             self.cameras.main.fadeOut(1500, 0, 0, 0);
             self.cameras.main.once("camerafadeoutcomplete", function () {
+                gameState.bgmContinuityActive = false;
+                gameState.currentBgmKey = null;
                 self.stopAllSounds();
                 setTimeout(function () {
                     game.scene.stop("PhaserEndingScene");

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -156,10 +156,12 @@ export class PhaserGameScene extends Phaser.Scene {
             this.stageEnemyPositionList = [];
         }
 
-        this.stageBg = this.add.tileSprite(0, 0, GW, GH, "stage_loop" + stageId);
+        var bgSuffix = gameState.hasCustomEnemies ? "stage_loop_c" : "stage_loop";
+        var bgEndSuffix = gameState.hasCustomEnemies ? "stage_end_c" : "stage_end";
+        this.stageBg = this.add.tileSprite(0, 0, GW, GH, bgSuffix + stageId);
         this.stageBg.setOrigin(0, 0);
 
-        this.stageEndBg = this.add.image(0, 0, "stage_end" + stageId);
+        this.stageEndBg = this.add.image(0, 0, bgEndSuffix + stageId);
         this.stageEndBg.setOrigin(0, 0);
         this.stageEndBg.y = -this.stageEndBg.height;
         this.stageEndBg.setVisible(false);
@@ -491,7 +493,36 @@ export class PhaserGameScene extends Phaser.Scene {
 
         var game = this.game;
         this.time.delayedCall(2500, function () {
-            self.stopAllSounds();
+            // Check if next stage uses same custom audio URL for BGM continuity
+            var urls = gameState.bgmSourceURLs;
+            var currentKey = self.stageBgmName;
+            var nextStageId = gameState.stageId + 1;
+            var bossNames = ["bison", "barlog", "sagat", "vega", "fang"];
+            var nextBossName = bossNames[nextStageId] || "";
+            var nextKey = nextBossName ? "boss_" + nextBossName + "_bgm" : "";
+            var sameBgm = urls && currentKey && nextKey &&
+                urls[currentKey] && urls[nextKey] &&
+                urls[currentKey] === urls[nextKey];
+
+            if (sameBgm) {
+                // Pause current BGM instead of stopping, stop everything else
+                try {
+                    var sounds = self.sound.getAll();
+                    for (var si = 0; si < sounds.length; si++) {
+                        if (sounds[si].key === currentKey) {
+                            sounds[si].pause();
+                        } else if (sounds[si].isPlaying) {
+                            sounds[si].stop();
+                        }
+                    }
+                } catch (e) { self.stopAllSounds(); }
+                gameState.bgmContinuityActive = true;
+                gameState.currentBgmKey = currentKey;
+            } else {
+                self.stopAllSounds();
+                gameState.bgmContinuityActive = false;
+            }
+
             gameState.stageId++;
             setTimeout(function () {
                 game.scene.stop("PhaserGameScene");
@@ -501,6 +532,8 @@ export class PhaserGameScene extends Phaser.Scene {
     }
 
     timeoverComplete() {
+        gameState.bgmContinuityActive = false;
+        gameState.currentBgmKey = null;
         gameState.score = this.scoreCount;
         gameState.maxCombo = Math.max(gameState.maxCombo || 0, this.maxCombo);
 
@@ -782,6 +815,23 @@ export class PhaserGameScene extends Phaser.Scene {
         var name = bossNames[stageId] || "bison";
         var key = "boss_" + name + "_bgm";
         this.stageBgmName = key;
+
+        // Resume paused BGM if same custom audio URL carries over
+        if (gameState.bgmContinuityActive && gameState.currentBgmKey) {
+            try {
+                var paused = this.sound.get(gameState.currentBgmKey);
+                if (paused && paused.isPaused) {
+                    paused.resume();
+                    this.stageBgmName = gameState.currentBgmKey;
+                    gameState.bgmContinuityActive = false;
+                    gameState.currentBgmKey = null;
+                    return;
+                }
+            } catch (e) {}
+            gameState.bgmContinuityActive = false;
+            gameState.currentBgmKey = null;
+        }
+
         this.playBgm(key, 0.4);
     }
 

--- a/src/phaser/ui/StageBackground.js
+++ b/src/phaser/ui/StageBackground.js
@@ -1,4 +1,5 @@
 import { GAME_DIMENSIONS } from "../../constants.js";
+import { gameState } from "../../gameState.js";
 
 var GW = GAME_DIMENSIONS.WIDTH;
 var GH = GAME_DIMENSIONS.HEIGHT;
@@ -7,10 +8,12 @@ export class PhaserStageBackground {
     constructor(scene, stageId) {
         this.scene = scene;
 
-        this.stageBg = scene.add.tileSprite(0, 0, GW, GH, "stage_loop" + stageId);
+        var bgPrefix = gameState.hasCustomEnemies ? "stage_loop_c" : "stage_loop";
+        var bgEndPrefix = gameState.hasCustomEnemies ? "stage_end_c" : "stage_end";
+        this.stageBg = scene.add.tileSprite(0, 0, GW, GH, bgPrefix + stageId);
         this.stageBg.setOrigin(0, 0);
 
-        this.stageEndBg = scene.add.image(0, 0, "stage_end" + stageId);
+        this.stageEndBg = scene.add.image(0, 0, bgEndPrefix + stageId);
         this.stageEndBg.setOrigin(0, 0);
         this.stageEndBg.y = -this.stageEndBg.height;
         this.stageEndBg.setVisible(false);


### PR DESCRIPTION
## Summary
- Load per-stage backgrounds (stage_loop0-4) when enemies are not customized (turbo/preloaded levels); fall back to shared bg3/bg4 when custom enemyData is detected
- Level-editor audio editor accepts URL input alongside file upload; URLs saved to Firebase (`customAudioURLs`) and loaded by the game via `this.load.audio(key, url)`
- When consecutive stages share the same BGM audio URL, music pauses during AdvScene and resumes on next stage instead of restarting

## Test plan
- [ ] Default game (no Firebase/editor): verify each stage shows its unique background
- [ ] Editor with custom enemyData: verify stages 0-3 show shared stage_loop3 background
- [ ] Level-editor audio: paste a URL, verify it loads, previews, and saves to Firebase
- [ ] Load a Firebase level with customAudioURLs: verify game loads audio from URLs
- [ ] Set same BGM URL for consecutive stages: verify music pauses during AdvScene and resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)