### PR TITLE
Add package.json to cordova-plugin-ios-haptics

### DIFF
--- a/plugins/cordova-plugin-ios-haptics/package.json
+++ b/plugins/cordova-plugin-ios-haptics/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cordova-plugin-ios-haptics",
+  "version": "1.0.0",
+  "description": "Lightweight iOS haptic feedback using UIFeedbackGenerator APIs",
+  "cordova": {
+    "id": "cordova-plugin-ios-haptics",
+    "platforms": ["ios"]
+  },
+  "keywords": ["cordova", "ios", "haptics", "ecosystem:cordova", "cordova-ios"],
+  "author": "easierbycode",
+  "license": "MIT"
+}


### PR DESCRIPTION
Cordova requires a valid package.json to install local plugins.

https://claude.ai/code/session_01N3YcXZLyjwUBrJxjhGf5Km