### PR TITLE
Set SwiftVersion 5.0 for iOS to fix xcodebuild archive failure

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -64,6 +64,8 @@
         <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
         <!-- Remote debugging: make WKWebView inspectable via Safari/chrome://inspect -->
         <preference name="InspectableWebview" value="true" />
+        <!-- Swift version required for cordova-plugin-ios-haptics -->
+        <preference name="SwiftVersion" value="5.0" />
 
         <icon src="icons/ios/icon-20.png" width="20" height="20" />
         <icon src="icons/ios/icon-20@2x.png" width="40" height="40" />


### PR DESCRIPTION
The haptics plugin uses Swift, but SWIFT_VERSION was empty causing "SWIFT_VERSION '' is unsupported" during xcodebuild archive.

https://claude.ai/code/session_01N3YcXZLyjwUBrJxjhGf5Km