### PR TITLE
Fix iOS canvas bottom-position and Android haptic feedback

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -31,6 +31,11 @@
     <hook type="after_prepare" src="hooks/after_prepare.js" />
 
     <platform name="android">
+        <!-- Required for navigator.vibrate() haptic feedback (was previously
+             provided by cordova-plugin-vibration, now removed) -->
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.VIBRATE" xmlns:android="http://schemas.android.com/apk/res/android" />
+        </config-file>
         <icon density="ldpi" src="res/android/ldpi.png" />
         <icon density="mdpi" src="res/android/mdpi.png" />
         <icon density="hdpi" src="res/android/hdpi.png" />

--- a/phaser-game.html
+++ b/phaser-game.html
@@ -328,11 +328,18 @@
             pc.style.width = Math.floor(256 * scale) + "px";
             pc.style.height = Math.floor(480 * scale) + "px";
 
-            // Apply canvas position class from gameState
+            // Apply canvas position class from gameState (fall back to
+            // localStorage directly in case the game module hasn't loaded yet)
             var container = document.getElementById("phaser-canvas");
             if (container) {
                 var gs = window.__GAME_STATE__;
-                var pos = (gs && gs.canvasPosition === "bottom") ? "bottom" : "center";
+                var pos = (gs && typeof gs.canvasPosition === "string")
+                    ? gs.canvasPosition
+                    : null;
+                if (!pos) {
+                    try { pos = localStorage.getItem("canvasPosition"); } catch (e) {}
+                }
+                if (!pos) pos = "bottom";
                 container.classList.toggle("canvas-bottom", pos === "bottom");
             }
 


### PR DESCRIPTION
iOS: fitCanvas() now reads localStorage directly as fallback when __GAME_STATE__ hasn't been initialized yet (race condition with Cordova's bundled script loading).

Android: Add VIBRATE permission to AndroidManifest.xml so navigator.vibrate() works — the permission was lost when cordova-plugin-vibration was removed.

https://claude.ai/code/session_01N3YcXZLyjwUBrJxjhGf5Km