### PR TITLE
Fix game state not resetting stageId on continue and new game

### DIFF
--- a/src/phaser/ContinueScene.js
+++ b/src/phaser/ContinueScene.js
@@ -416,6 +416,7 @@ export class PhaserContinueScene extends Phaser.Scene {
                         gameState.shootMode = recipe.playerData.defaultShootName;
                         gameState.shootSpeed = recipe.playerData.defaultShootSpeed;
                     }
+                    gameState.stageId = 0;
                     gameState.continueCnt = Number(gameState.continueCnt || 0) + 1;
                     gameState.score = gameState.continueCnt;
                     nextScene = "PhaserGameScene";

--- a/src/phaser/EndingScene.js
+++ b/src/phaser/EndingScene.js
@@ -201,6 +201,7 @@ export class PhaserEndingScene extends Phaser.Scene {
             self.cameras.main.once("camerafadeoutcomplete", function () {
                 gameState.bgmContinuityActive = false;
                 gameState.currentBgmKey = null;
+                gameState.stageId = 0;
                 self.stopAllSounds();
                 setTimeout(function () {
                     game.scene.stop("PhaserEndingScene");

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -390,7 +390,7 @@ export class PhaserTitleScene extends Phaser.Scene {
         gameState.maxCombo = 0;
         gameState.score = 0;
         gameState.spgage = 0;
-        gameState.stageId = gameState.stageId || 0;
+        gameState.stageId = 0;
         gameState.continueCnt = 0;
         gameState.akebonoCnt = 0;
         gameState.shortFlg = false;


### PR DESCRIPTION
- ContinueScene: reset stageId to 0 when player continues after game over
- EndingScene: reset stageId to 0 when returning to title after beating game
- TitleScene: always reset stageId to 0 instead of preserving stale value

https://claude.ai/code/session_01MZFWdfDt6NNLqQD24UzetN