### PR TITLE
Lower explosion sound volume to half to reduce audio clipping

### DIFF
--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -1161,7 +1161,7 @@ export class PhaserGameScene extends Phaser.Scene {
                             this.showScorePopup(eBullet.x, eBullet.y, ebScore, ebRatio);
                         }
                         this.showExplosion(eBullet.x, eBullet.y);
-                        this.playSound("se_explosion", 0.35);
+                        this.playSound("se_explosion", 0.175);
                         eBullet.destroy();
                         this.enemyBullets.splice(eb, 1);
                         ebDestroyed = true;

--- a/src/phaser/effects/Explosions.js
+++ b/src/phaser/effects/Explosions.js
@@ -66,7 +66,7 @@ export function spExplosions(scene) {
                 });
 
                 if (idx % 16 === 0) {
-                    scene.playSound("se_sp_explosion", 0.3);
+                    scene.playSound("se_sp_explosion", 0.15);
                 }
             });
         })(n);

--- a/src/phaser/game-objects/Boss.js
+++ b/src/phaser/game-objects/Boss.js
@@ -685,7 +685,7 @@ export function bossDie(scene, boss) {
                 var ex = startX + Math.random() * bw - bw / 2;
                 var ey = startY + Math.random() * bh - bh / 2;
                 showBossExplosion(scene, ex, ey);
-                scene.playSound("se_explosion", 0.35);
+                scene.playSound("se_explosion", 0.175);
             });
         })(ei);
     }

--- a/src/phaser/game-objects/Enemy.js
+++ b/src/phaser/game-objects/Enemy.js
@@ -214,7 +214,7 @@ export function enemyDie(scene, enemy, isSp) {
     triggerHaptic("kill");
     scene.showExplosion(enemy.x, enemy.y);
     scene.showScorePopup(enemy.x, enemy.y, score, ratio);
-    scene.playSound("se_explosion", 0.35);
+    scene.playSound("se_explosion", 0.175);
 
     var idx = scene.enemies.indexOf(enemy);
     if (idx >= 0) scene.enemies.splice(idx, 1);


### PR DESCRIPTION
When shoot-big collides with pyramid boss spiral bullets, many explosions fire simultaneously causing excessive volume. Halved all explosion sound volumes: se_explosion 0.35→0.175, se_sp_explosion 0.3→0.15.

https://claude.ai/code/session_01CSEyz9muhRd4chWQvX5JM2