### PR TITLE
Add Android sprite share plugin for detecting and importing sprites

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -101,4 +101,9 @@
          Exposes window.TapticEngine (impact/notification/selection).
          Installed via `cordova plugin add` in CI workflows (path is
          relative to the Cordova project, not this file). -->
+
+    <!-- Android sprite share: receive images via share intent, auto-detect
+         sprites, and add/replace them in game atlases.
+         Plugin source: plugins/cordova-plugin-sprite-share -->
+    <plugin name="cordova-plugin-sprite-share" spec="plugins/cordova-plugin-sprite-share" />
 </widget>

--- a/plugins/cordova-plugin-sprite-share/plugin.xml
+++ b/plugins/cordova-plugin-sprite-share/plugin.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+        id="cordova-plugin-sprite-share"
+        version="1.0.0">
+
+    <name>Sprite Share</name>
+    <description>Receive shared images via Android intent, auto-detect sprites, and add/replace them in game atlases.</description>
+
+    <js-module src="www/sprite-share.js" name="SpriteShare">
+        <clobbers target="SpriteShare" />
+    </js-module>
+
+    <platform name="android">
+        <source-file src="src/android/SpriteShareActivity.kt"
+                     target-dir="app/src/main/java/com/easierbycode/spriteshare" />
+
+        <!-- Register the share-receiver Activity in AndroidManifest -->
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <activity android:name="com.easierbycode.spriteshare.SpriteShareActivity"
+                      android:label="Sprite Share"
+                      android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+                      android:screenOrientation="portrait"
+                      android:exported="true"
+                      xmlns:android="http://schemas.android.com/apk/res/android">
+                <intent-filter>
+                    <action android:name="android.intent.action.SEND" />
+                    <category android:name="android.intent.category.DEFAULT" />
+                    <data android:mimeType="image/*" />
+                </intent-filter>
+            </activity>
+        </config-file>
+
+        <!-- Copy picker UI assets into the APK's www/sprite-share/ directory -->
+        <asset src="www/sprite-picker.html"    target="www/sprite-share/sprite-picker.html" />
+        <asset src="www/sprite-picker.css"     target="www/sprite-share/sprite-picker.css" />
+        <asset src="www/sprite-picker-app.js"  target="www/sprite-share/sprite-picker-app.js" />
+        <asset src="www/sprite-detect.js"      target="www/sprite-share/sprite-detect.js" />
+    </platform>
+</plugin>

--- a/plugins/cordova-plugin-sprite-share/src/android/SpriteShareActivity.kt
+++ b/plugins/cordova-plugin-sprite-share/src/android/SpriteShareActivity.kt
@@ -1,0 +1,221 @@
+package com.easierbycode.spriteshare
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.util.Base64
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Activity that receives shared images via ACTION_SEND intent,
+ * loads a WebView-based sprite picker UI, and lets the user
+ * detect / select / repack sprites into game atlases.
+ */
+class SpriteShareActivity : Activity() {
+
+    private lateinit var webView: WebView
+    private var sharedImageDataUrl: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Read the shared image from the intent
+        sharedImageDataUrl = readSharedImage()
+        if (sharedImageDataUrl == null) {
+            finish()
+            return
+        }
+
+        // Set up the WebView
+        webView = WebView(this).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.allowFileAccess = true
+            settings.allowFileAccessFromFileURLs = true
+            settings.allowUniversalAccessFromFileURLs = true
+            settings.useWideViewPort = true
+            settings.loadWithOverviewMode = true
+            settings.builtInZoomControls = true
+            settings.displayZoomControls = false
+
+            addJavascriptInterface(SpriteShareBridge(), "Android")
+
+            webChromeClient = WebChromeClient()
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    // Pass the shared image to JS once the page is loaded
+                    sharedImageDataUrl?.let { dataUrl ->
+                        val escaped = dataUrl.replace("'", "\\'")
+                        view?.evaluateJavascript("receiveSharedImage('$escaped')", null)
+                    }
+                }
+            }
+
+            loadUrl("file:///android_asset/www/sprite-share/sprite-picker.html")
+        }
+
+        setContentView(webView)
+    }
+
+    /**
+     * Read the shared image URI from the intent, convert to a base64 data URL.
+     */
+    private fun readSharedImage(): String? {
+        if (intent?.action != Intent.ACTION_SEND) return null
+
+        val imageUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_STREAM)
+        }
+
+        if (imageUri == null) return null
+
+        return try {
+            val inputStream = contentResolver.openInputStream(imageUri) ?: return null
+            val buffer = ByteArrayOutputStream()
+            val chunk = ByteArray(8192)
+            var bytesRead: Int
+            while (inputStream.read(chunk).also { bytesRead = it } != -1) {
+                buffer.write(chunk, 0, bytesRead)
+            }
+            inputStream.close()
+
+            val bytes = buffer.toByteArray()
+            val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+
+            // Detect MIME type from intent or fall back to png
+            val mimeType = intent.type ?: "image/png"
+            "data:$mimeType;base64,$base64"
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    /**
+     * JavaScript bridge exposed as `Android.*` in the WebView.
+     */
+    inner class SpriteShareBridge {
+
+        /**
+         * Read an atlas JSON file from bundled www/assets/.
+         * @param atlasName e.g. "game_asset" → reads "assets/game_asset.json"
+         *                  Also checks for editor-repacked "_game_asset.json" in internal storage first.
+         */
+        @JavascriptInterface
+        fun getAtlasJson(atlasName: String): String {
+            // Check internal storage first (editor-repacked version)
+            val internalFile = File(filesDir, "assets/_${atlasName}.json")
+            if (internalFile.exists()) {
+                return internalFile.readText()
+            }
+            // Fall back to bundled assets
+            return try {
+                assets.open("www/assets/$atlasName.json").bufferedReader().readText()
+            } catch (e: Exception) {
+                // Try without www/ prefix
+                try {
+                    assets.open("www/assets/${atlasName}.json").bufferedReader().readText()
+                } catch (e2: Exception) {
+                    "{\"frames\":{},\"meta\":{}}"
+                }
+            }
+        }
+
+        /**
+         * Read an atlas PNG image and return as a base64 data URL.
+         */
+        @JavascriptInterface
+        fun getAtlasImageBase64(atlasName: String): String {
+            // Check internal storage first
+            val internalFile = File(filesDir, "assets/img/_${atlasName}.png")
+            if (internalFile.exists()) {
+                val bytes = internalFile.readBytes()
+                val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+                return "data:image/png;base64,$base64"
+            }
+            // Fall back to bundled assets
+            return try {
+                val inputStream = assets.open("www/assets/img/$atlasName.png")
+                val buffer = ByteArrayOutputStream()
+                val chunk = ByteArray(8192)
+                var bytesRead: Int
+                while (inputStream.read(chunk).also { bytesRead = it } != -1) {
+                    buffer.write(chunk, 0, bytesRead)
+                }
+                inputStream.close()
+                val base64 = Base64.encodeToString(buffer.toByteArray(), Base64.NO_WRAP)
+                "data:image/png;base64,$base64"
+            } catch (e: Exception) {
+                ""
+            }
+        }
+
+        /**
+         * Save a repacked atlas (PNG + JSON) to internal storage.
+         * Uses the _ prefix convention so Phaser picks up repacked atlases.
+         */
+        @JavascriptInterface
+        fun saveAtlas(atlasName: String, pngBase64: String, jsonString: String): Boolean {
+            return try {
+                // Ensure directories exist
+                val imgDir = File(filesDir, "assets/img")
+                imgDir.mkdirs()
+                val jsonDir = File(filesDir, "assets")
+                jsonDir.mkdirs()
+
+                // Save PNG (strip data URL prefix if present)
+                val pngData = pngBase64.substringAfter("base64,", pngBase64)
+                val pngBytes = Base64.decode(pngData, Base64.DEFAULT)
+                FileOutputStream(File(imgDir, "_${atlasName}.png")).use { it.write(pngBytes) }
+
+                // Save JSON
+                FileOutputStream(File(jsonDir, "_${atlasName}.json")).use {
+                    it.write(jsonString.toByteArray())
+                }
+
+                true
+            } catch (e: Exception) {
+                e.printStackTrace()
+                false
+            }
+        }
+
+        /**
+         * Check if an editor-repacked atlas exists in internal storage.
+         */
+        @JavascriptInterface
+        fun hasRepackedAtlas(atlasName: String): Boolean {
+            val jsonFile = File(filesDir, "assets/_${atlasName}.json")
+            val pngFile = File(filesDir, "assets/img/_${atlasName}.png")
+            return jsonFile.exists() && pngFile.exists()
+        }
+
+        /**
+         * Close the sprite picker Activity.
+         */
+        @JavascriptInterface
+        fun closeActivity() {
+            runOnUiThread { finish() }
+        }
+    }
+
+    override fun onBackPressed() {
+        if (webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            super.onBackPressed()
+        }
+    }
+}

--- a/plugins/cordova-plugin-sprite-share/www/sprite-detect.js
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-detect.js
@@ -1,0 +1,359 @@
+/**
+ * Sprite detection algorithms ported from spriteX/src/atlasManager.ts
+ * Pure functions -- no external dependencies.
+ */
+(function () {
+  "use strict";
+
+  function clamp(n, lo, hi) {
+    return Math.max(lo, Math.min(hi, n));
+  }
+
+  function colorDistance(a, b) {
+    const dr = a.r - b.r;
+    const dg = a.g - b.g;
+    const db = a.b - b.b;
+    return Math.sqrt(dr * dr + dg * dg + db * db);
+  }
+
+  function percentile(arr, p) {
+    if (arr.length === 0) return 0;
+    const sorted = [...arr].sort((x, y) => x - y);
+    const idx = clamp(
+      Math.floor((p / 100) * (sorted.length - 1)),
+      0,
+      sorted.length - 1
+    );
+    return sorted[idx];
+  }
+
+  function hexToRgb(hex) {
+    const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return m
+      ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) }
+      : null;
+  }
+
+  function rgbToHex(rgb) {
+    const to2 = (v) => clamp(v | 0, 0, 255).toString(16).padStart(2, "0");
+    return `#${to2(rgb.r)}${to2(rgb.g)}${to2(rgb.b)}`;
+  }
+
+  /** Border sampling + dominant color (quantized) */
+  function sampleBorderDominant(imageData, sampleStride) {
+    if (sampleStride === undefined) sampleStride = 2;
+    const { width, height, data } = imageData;
+    const samples = [];
+    const pick = (x, y) => {
+      const i = (y * width + x) * 4;
+      samples.push({ r: data[i], g: data[i + 1], b: data[i + 2] });
+    };
+    for (let x = 0; x < width; x += sampleStride) {
+      pick(x, 0);
+      pick(x, height - 1);
+    }
+    for (let y = 0; y < height; y += sampleStride) {
+      pick(0, y);
+      pick(width - 1, y);
+    }
+    if (!samples.length) return { dominant: null, distances: [] };
+
+    const qKey = (c) =>
+      `${(c.r >> 2) << 2},${(c.g >> 2) << 2},${(c.b >> 2) << 2}`;
+    const counts = new Map();
+    for (const s of samples) {
+      const k = qKey(s);
+      const v = counts.get(k);
+      if (v) v.count++;
+      else counts.set(k, { rgb: s, count: 1 });
+    }
+
+    let dominant = null;
+    let best = -1;
+    counts.forEach((v) => {
+      if (v.count > best) {
+        best = v.count;
+        dominant = v.rgb;
+      }
+    });
+
+    const distances = dominant
+      ? samples.map((s) => colorDistance(s, dominant))
+      : [];
+    return { dominant, distances };
+  }
+
+  function computeAdaptiveTolerance(distances, min, max) {
+    if (min === undefined) min = 6;
+    if (max === undefined) max = 48;
+    if (!distances.length) return 12;
+    const p90 = percentile(distances, 90);
+    const tol = Math.ceil(p90 + 2);
+    return clamp(tol, min, max);
+  }
+
+  function keyOutBackground(imageData, bg, tolerance) {
+    const { data } = imageData;
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      if (colorDistance({ r, g, b }, bg) <= tolerance) {
+        data[i + 3] = 0;
+      }
+    }
+  }
+
+  /** Flood-fill connected-component sprite detection */
+  function detectSpritesFromImageData(imageData, opts) {
+    opts = opts || {};
+    const width = imageData.width;
+    const height = imageData.height;
+    const data = imageData.data;
+
+    const alphaThreshold = opts.alphaThreshold != null ? opts.alphaThreshold : 1;
+    const minArea = opts.minArea != null ? opts.minArea : 2;
+    const use8Conn = !!opts.use8Conn;
+    const nearTolerance = opts.tolerance != null ? opts.tolerance : 12;
+    const userBg = opts.bgColor || null;
+
+    let hasTransparency = false;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] <= alphaThreshold) {
+        hasTransparency = true;
+        break;
+      }
+    }
+
+    let inferredBg = userBg;
+    if (!inferredBg && !hasTransparency) {
+      const s = sampleBorderDominant(imageData);
+      inferredBg = s.dominant;
+    }
+
+    const pxCount = width * height;
+    const visited = new Uint8Array(pxCount);
+    const bgMark = new Uint8Array(pxCount);
+
+    const neighbors = use8Conn
+      ? [
+          { dx: 1, dy: 0 },
+          { dx: -1, dy: 0 },
+          { dx: 0, dy: 1 },
+          { dx: 0, dy: -1 },
+          { dx: 1, dy: 1 },
+          { dx: 1, dy: -1 },
+          { dx: -1, dy: 1 },
+          { dx: -1, dy: -1 },
+        ]
+      : [
+          { dx: 1, dy: 0 },
+          { dx: -1, dy: 0 },
+          { dx: 0, dy: 1 },
+          { dx: 0, dy: -1 },
+        ];
+
+    const getIdx = (x, y) => (y * width + x) * 4;
+    const isTransparent = (a) => a <= alphaThreshold;
+    const nearBg = (r, g, b) => {
+      if (!inferredBg) return false;
+      return colorDistance({ r, g, b }, inferredBg) <= nearTolerance;
+    };
+
+    const q = [];
+    const pushIfBg = (x, y) => {
+      if (x < 0 || y < 0 || x >= width || y >= height) return;
+      const lin = y * width + x;
+      if (bgMark[lin]) return;
+      const i = getIdx(x, y);
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const a = data[i + 3];
+      const isBg = isTransparent(a) || nearBg(r, g, b);
+      if (isBg) {
+        bgMark[lin] = 1;
+        q.push({ x, y });
+      }
+    };
+
+    for (let x = 0; x < width; x++) {
+      pushIfBg(x, 0);
+      pushIfBg(x, height - 1);
+    }
+    for (let y = 0; y < height; y++) {
+      pushIfBg(0, y);
+      pushIfBg(width - 1, y);
+    }
+
+    while (q.length) {
+      const pt = q.pop();
+      for (const nb of neighbors) {
+        pushIfBg(pt.x + nb.dx, pt.y + nb.dy);
+      }
+    }
+
+    const isSpritePixel = (x, y) => {
+      const lin = y * width + x;
+      if (bgMark[lin]) return false;
+      const i = getIdx(x, y);
+      const a = data[i + 3];
+      if (isTransparent(a)) return false;
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      if (inferredBg && nearBg(r, g, b)) return false;
+      return true;
+    };
+
+    function floodFill(startX, startY) {
+      const stack = [{ x: startX, y: startY }];
+      let minX = startX,
+        minY = startY,
+        maxX = startX,
+        maxY = startY,
+        area = 0;
+
+      visited[startY * width + startX] = 1;
+
+      while (stack.length) {
+        const pt = stack.pop();
+        area++;
+        if (pt.x < minX) minX = pt.x;
+        if (pt.x > maxX) maxX = pt.x;
+        if (pt.y < minY) minY = pt.y;
+        if (pt.y > maxY) maxY = pt.y;
+
+        for (const nb of neighbors) {
+          const nx = pt.x + nb.dx;
+          const ny = pt.y + nb.dy;
+          if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue;
+          const lin = ny * width + nx;
+          if (visited[lin]) continue;
+          if (isSpritePixel(nx, ny)) {
+            visited[lin] = 1;
+            stack.push({ x: nx, y: ny });
+          }
+        }
+      }
+
+      return {
+        x: minX,
+        y: minY,
+        w: maxX - minX + 1,
+        h: maxY - minY + 1,
+        area: area,
+      };
+    }
+
+    const out = [];
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const lin = y * width + x;
+        if (visited[lin] || bgMark[lin]) continue;
+        if (isSpritePixel(x, y)) {
+          const box = floodFill(x, y);
+          if ((box.area || 0) >= minArea) {
+            delete box.area;
+            out.push(box);
+          }
+        } else {
+          visited[lin] = 1;
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Auto bg detect, key-out, then detect on keyed result */
+  function smartDetectSprites(ctx, width, height, explicitBg) {
+    const imageData = ctx.getImageData(0, 0, width, height);
+
+    let hasTransparency = false;
+    for (let i = 3; i < imageData.data.length; i += 4) {
+      if (imageData.data[i] < 255) {
+        hasTransparency = true;
+        break;
+      }
+    }
+
+    if (hasTransparency) {
+      const sprites = detectSpritesFromImageData(imageData, {
+        alphaThreshold: 1,
+        minArea: 2,
+        use8Conn: false,
+      });
+      return { sprites, bgColor: null, tolerance: 0, usedKeyOut: false };
+    }
+
+    const { dominant, distances } = sampleBorderDominant(imageData);
+    const computedBg = explicitBg || dominant || null;
+    const tolerance = computeAdaptiveTolerance(distances, 6, 48);
+
+    const workData = new ImageData(
+      new Uint8ClampedArray(imageData.data),
+      imageData.width,
+      imageData.height
+    );
+
+    let usedKeyOut = false;
+    if (computedBg) {
+      keyOutBackground(workData, computedBg, tolerance);
+      usedKeyOut = true;
+    }
+
+    const sprites = detectSpritesFromImageData(workData, {
+      bgColor: computedBg,
+      tolerance,
+      minArea: 2,
+      use8Conn: false,
+      alphaThreshold: 1,
+    });
+
+    return { sprites, bgColor: computedBg, tolerance, usedKeyOut };
+  }
+
+  /** Extract selected sprite regions as data URLs */
+  function extractSpriteDataURLs(originalCanvas, boxes, opts) {
+    opts = opts || {};
+    const out = {};
+    boxes.forEach((spr, idx) => {
+      const c = document.createElement("canvas");
+      c.width = spr.w;
+      c.height = spr.h;
+      const cctx = c.getContext("2d", { willReadFrequently: true });
+      cctx.imageSmoothingEnabled = false;
+      cctx.drawImage(
+        originalCanvas,
+        spr.x,
+        spr.y,
+        spr.w,
+        spr.h,
+        0,
+        0,
+        spr.w,
+        spr.h
+      );
+
+      if (opts.bgColor) {
+        const id = cctx.getImageData(0, 0, spr.w, spr.h);
+        keyOutBackground(id, opts.bgColor, opts.tolerance || 12);
+        cctx.putImageData(id, 0, 0);
+      }
+
+      out["sprite_" + idx] = c.toDataURL("image/png");
+    });
+    return out;
+  }
+
+  // Expose on window for content script access
+  window.SpriteDetect = {
+    smartDetectSprites,
+    detectSpritesFromImageData,
+    extractSpriteDataURLs,
+    keyOutBackground,
+    hexToRgb,
+    rgbToHex,
+    colorDistance,
+  };
+})();

--- a/plugins/cordova-plugin-sprite-share/www/sprite-picker-app.js
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-picker-app.js
@@ -1,0 +1,513 @@
+/**
+ * Sprite Picker App — Android Share edition
+ *
+ * Receives a shared image from SpriteShareActivity (Kotlin),
+ * runs sprite detection, lets user select sprites, and saves
+ * them into a game atlas via the Android JS bridge.
+ *
+ * Reuses:
+ *  - SpriteDetect (sprite-detect.js) — verbatim from Chrome extension
+ *  - Atlas repack algorithm — ported from level-editor.html
+ */
+(function () {
+  "use strict";
+
+  // ── State ──
+
+  let sourceCanvas = null;     // offscreen canvas with the loaded image
+  let overlayCanvas = null;
+  let overlayCtx = null;
+  let detected = [];           // array of { x, y, w, h }
+  let selected = new Set();
+  let detectionResult = null;  // { bgColor, tolerance, usedKeyOut }
+
+  // Atlas state for replace mode
+  let atlasData = null;        // parsed JSON
+  let atlasImage = null;       // Image element
+
+  // ── DOM refs ──
+
+  const srcCanvas = document.getElementById("source-canvas");
+  const ovrCanvas = document.getElementById("overlay-canvas");
+  const thumbsStrip = document.getElementById("thumbs-strip");
+  const thumbsEmpty = document.getElementById("thumbs-empty");
+  const statusEl = document.getElementById("status");
+  const atlasSelect = document.getElementById("atlas-select");
+  const modeSelect = document.getElementById("mode-select");
+  const frameRow = document.getElementById("frame-row");
+  const frameSelect = document.getElementById("frame-select");
+  const saveBtn = document.getElementById("save-btn");
+  const selectAllBtn = document.getElementById("select-all-btn");
+  const clearBtn = document.getElementById("clear-btn");
+  const closeBtn = document.getElementById("close-btn");
+
+  // ── Init ──
+
+  closeBtn.addEventListener("click", () => {
+    if (typeof Android !== "undefined") Android.closeActivity();
+  });
+
+  modeSelect.addEventListener("change", () => {
+    frameRow.style.display = modeSelect.value === "replace" ? "flex" : "none";
+    if (modeSelect.value === "replace") loadFrameList();
+  });
+
+  atlasSelect.addEventListener("change", () => {
+    if (modeSelect.value === "replace") loadFrameList();
+  });
+
+  saveBtn.addEventListener("click", saveToAtlas);
+  selectAllBtn.addEventListener("click", () => {
+    for (let i = 0; i < detected.length; i++) selected.add(i);
+    drawOverlay();
+    updateThumbs();
+  });
+  clearBtn.addEventListener("click", () => {
+    selected.clear();
+    drawOverlay();
+    updateThumbs();
+  });
+
+  // Touch/click on overlay to toggle sprite selection
+  ovrCanvas.addEventListener("click", onOverlayTap);
+  // Also support touch for more responsive mobile feel
+  let touchStartPos = null;
+  ovrCanvas.addEventListener("touchstart", (e) => {
+    if (e.touches.length === 1) {
+      touchStartPos = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+  }, { passive: true });
+  ovrCanvas.addEventListener("touchend", (e) => {
+    if (!touchStartPos || e.changedTouches.length !== 1) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - touchStartPos.x;
+    const dy = t.clientY - touchStartPos.y;
+    // Only treat as tap if finger didn't move much (not a scroll/pinch)
+    if (Math.abs(dx) < 12 && Math.abs(dy) < 12) {
+      e.preventDefault();
+      onOverlayTapAt(t.clientX, t.clientY);
+    }
+    touchStartPos = null;
+  });
+
+  // ── Entry point called from Kotlin ──
+
+  window.receiveSharedImage = async function (dataURL) {
+    setStatus("loading", "Running sprite detection...");
+
+    try {
+      const img = new Image();
+      img.src = dataURL;
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = reject;
+      });
+
+      const w = img.naturalWidth;
+      const h = img.naturalHeight;
+
+      // Draw to source canvas
+      srcCanvas.width = w;
+      srcCanvas.height = h;
+      const ctx = srcCanvas.getContext("2d", { willReadFrequently: true });
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(img, 0, 0);
+      sourceCanvas = srcCanvas;
+
+      // Set up overlay canvas
+      ovrCanvas.width = w;
+      ovrCanvas.height = h;
+      overlayCanvas = ovrCanvas;
+      overlayCtx = ovrCanvas.getContext("2d");
+      overlayCtx.imageSmoothingEnabled = false;
+
+      // Sync displayed sizes so overlay aligns with source
+      syncCanvasSizes();
+
+      // Run detection
+      const result = window.SpriteDetect.smartDetectSprites(ctx, w, h);
+      detected = result.sprites;
+      detectionResult = result;
+      selected = new Set();
+
+      if (detected.length === 0) {
+        setStatus("info", "No sprites detected in this image.");
+        return;
+      }
+
+      drawOverlay();
+      updateThumbs();
+      setStatus("info", "Detected " + detected.length + " sprites. Tap to select.");
+    } catch (err) {
+      setStatus("error", "Detection failed: " + err.message);
+    }
+  };
+
+  // Keep overlay sized to match the source canvas's displayed size
+  function syncCanvasSizes() {
+    const wrap = document.getElementById("canvas-wrap");
+    const displayW = srcCanvas.offsetWidth;
+    const displayH = srcCanvas.offsetHeight;
+    ovrCanvas.style.width = displayW + "px";
+    ovrCanvas.style.height = displayH + "px";
+  }
+
+  // ── Overlay drawing ──
+
+  function drawOverlay() {
+    if (!overlayCtx || !overlayCanvas) return;
+    overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+    overlayCtx.lineWidth = 2;
+
+    for (let i = 0; i < detected.length; i++) {
+      const s = detected[i];
+      overlayCtx.strokeStyle = selected.has(i)
+        ? "rgba(0,200,0,0.9)"
+        : "rgba(255,0,0,0.85)";
+      overlayCtx.strokeRect(s.x + 0.5, s.y + 0.5, s.w - 1, s.h - 1);
+    }
+  }
+
+  // ── Overlay tap handling ──
+
+  function onOverlayTap(ev) {
+    onOverlayTapAt(ev.clientX, ev.clientY);
+  }
+
+  function onOverlayTapAt(clientX, clientY) {
+    if (!overlayCanvas || !detected.length) return;
+    const rect = overlayCanvas.getBoundingClientRect();
+    const scaleX = overlayCanvas.width / rect.width;
+    const scaleY = overlayCanvas.height / rect.height;
+    const x = Math.floor((clientX - rect.left) * scaleX);
+    const y = Math.floor((clientY - rect.top) * scaleY);
+
+    const idx = detected.findIndex(
+      (s) => x >= s.x && x < s.x + s.w && y >= s.y && y < s.y + s.h
+    );
+
+    if (idx >= 0) {
+      if (selected.has(idx)) selected.delete(idx);
+      else selected.add(idx);
+      drawOverlay();
+      updateThumbs();
+    }
+  }
+
+  // ── Thumbnails strip ──
+
+  function updateThumbs() {
+    thumbsStrip.innerHTML = "";
+    saveBtn.disabled = selected.size === 0;
+
+    if (!selected.size) {
+      const span = document.createElement("span");
+      span.id = "thumbs-empty";
+      span.textContent = "No sprites selected";
+      thumbsStrip.appendChild(span);
+      return;
+    }
+
+    const sorted = [...selected].sort((a, b) => {
+      const sa = detected[a];
+      const sb = detected[b];
+      if (sa.y !== sb.y) return sa.y - sb.y;
+      return sa.x - sb.x;
+    });
+
+    sorted.forEach((i) => {
+      const s = detected[i];
+      const c = document.createElement("canvas");
+      c.width = s.w;
+      c.height = s.h;
+      const cctx = c.getContext("2d");
+      cctx.imageSmoothingEnabled = false;
+      cctx.drawImage(sourceCanvas, s.x, s.y, s.w, s.h, 0, 0, s.w, s.h);
+
+      const img = document.createElement("img");
+      img.src = c.toDataURL("image/png");
+      img.className = "sp-thumb selected";
+      img.title = s.w + "x" + s.h + " @ (" + s.x + "," + s.y + ")";
+      img.addEventListener("click", () => {
+        selected.delete(i);
+        drawOverlay();
+        updateThumbs();
+      });
+      thumbsStrip.appendChild(img);
+    });
+  }
+
+  // ── Frame list for replace mode ──
+
+  async function loadFrameList() {
+    frameSelect.innerHTML = '<option value="">-- Loading... --</option>';
+
+    try {
+      const atlasName = atlasSelect.value;
+      const jsonStr = Android.getAtlasJson(atlasName);
+      const data = JSON.parse(jsonStr);
+      const frames = Object.keys(data.frames || {});
+
+      frameSelect.innerHTML = "";
+      if (!frames.length) {
+        frameSelect.innerHTML = '<option value="">-- No frames --</option>';
+        return;
+      }
+      frames.forEach((name) => {
+        const opt = document.createElement("option");
+        opt.value = name;
+        opt.textContent = name;
+        frameSelect.appendChild(opt);
+      });
+    } catch (err) {
+      frameSelect.innerHTML =
+        '<option value="">-- Error: ' + err.message + " --</option>";
+    }
+  }
+
+  // ── Save to atlas ──
+
+  async function saveToAtlas() {
+    if (!selected.size || !sourceCanvas) {
+      setStatus("error", "No sprites selected");
+      return;
+    }
+
+    const atlasName = atlasSelect.value;
+    const mode = modeSelect.value;
+    const frameName = mode === "replace" ? frameSelect.value : null;
+
+    if (mode === "replace" && !frameName) {
+      setStatus("error", "Select a frame to replace");
+      return;
+    }
+
+    setStatus("loading", "Loading atlas...");
+
+    try {
+      // Load current atlas
+      const jsonStr = Android.getAtlasJson(atlasName);
+      atlasData = JSON.parse(jsonStr);
+
+      const imgDataUrl = Android.getAtlasImageBase64(atlasName);
+      if (imgDataUrl) {
+        atlasImage = new Image();
+        atlasImage.src = imgDataUrl;
+        await new Promise((resolve, reject) => {
+          atlasImage.onload = resolve;
+          atlasImage.onerror = reject;
+        });
+      } else {
+        atlasImage = null;
+      }
+
+      setStatus("loading", "Extracting sprites...");
+
+      // Extract selected sprites
+      const selectedBoxes = [...selected]
+        .sort((a, b) => {
+          const sa = detected[a];
+          const sb = detected[b];
+          if (sa.y !== sb.y) return sa.y - sb.y;
+          return sa.x - sb.x;
+        })
+        .map((i) => detected[i]);
+
+      const opts =
+        detectionResult && detectionResult.usedKeyOut
+          ? {
+              bgColor: detectionResult.bgColor,
+              tolerance: detectionResult.tolerance,
+            }
+          : {};
+
+      const dataURLs = window.SpriteDetect.extractSpriteDataURLs(
+        sourceCanvas,
+        selectedBoxes,
+        opts
+      );
+
+      // Build sprite entries
+      const extraSprites = [];
+      const replacedFrames = {};
+
+      const entries = Object.entries(dataURLs);
+      for (let idx = 0; idx < entries.length; idx++) {
+        const [key, dataURL] = entries[idx];
+        const box = selectedBoxes[idx];
+
+        const img = new Image();
+        img.src = dataURL;
+        await new Promise((r) => (img.onload = r));
+
+        const cv = document.createElement("canvas");
+        cv.width = img.width;
+        cv.height = img.height;
+        cv.getContext("2d").drawImage(img, 0, 0);
+
+        if (mode === "replace" && frameName) {
+          replacedFrames[frameName] = {
+            key: frameName,
+            canvas: cv,
+            w: img.width,
+            h: img.height,
+          };
+        } else {
+          extraSprites.push({
+            key: key + ".png",
+            canvas: cv,
+            w: img.width,
+            h: img.height,
+          });
+        }
+      }
+
+      setStatus("loading", "Repacking atlas...");
+
+      // Repack using the same algorithm as level-editor.html
+      const result = buildAtlasWithReplacements(
+        atlasData,
+        atlasImage,
+        replacedFrames,
+        extraSprites
+      );
+
+      // Build final JSON
+      const meta = atlasData.meta || {};
+      const finalJson = {
+        frames: result.frames,
+        meta: {
+          ...meta,
+          image: "_" + atlasName + ".png",
+          size: { w: result.canvas.width, h: result.canvas.height },
+        },
+      };
+
+      setStatus("loading", "Saving atlas...");
+
+      // Convert canvas to base64 PNG
+      const pngBase64 = result.canvas.toDataURL("image/png");
+      const jsonString = JSON.stringify(finalJson, null, 2);
+
+      const ok = Android.saveAtlas(atlasName, pngBase64, jsonString);
+
+      if (ok) {
+        setStatus("success", "Atlas saved! " + entries.length + " sprite(s) added.");
+      } else {
+        setStatus("error", "Failed to save atlas.");
+      }
+    } catch (err) {
+      setStatus("error", "Save failed: " + err.message);
+    }
+  }
+
+  // ── Atlas repack algorithm (ported from level-editor.html:1843-1877) ──
+
+  function buildAtlasWithReplacements(
+    atlasData,
+    atlasImage,
+    replacedFrames,
+    extraSprites
+  ) {
+    const all = [];
+    const frames = atlasData.frames || {};
+
+    for (const k in frames) {
+      const f = frames[k].frame;
+      if (!f) continue;
+
+      if (replacedFrames[k]) {
+        all.push(replacedFrames[k]);
+      } else {
+        const fc = document.createElement("canvas");
+        fc.width = f.w;
+        fc.height = f.h;
+        if (atlasImage) {
+          fc.getContext("2d").drawImage(
+            atlasImage,
+            f.x,
+            f.y,
+            f.w,
+            f.h,
+            0,
+            0,
+            f.w,
+            f.h
+          );
+        }
+        all.push({ key: k, canvas: fc, w: f.w, h: f.h });
+      }
+    }
+
+    all.push(...extraSprites);
+
+    // Sort by height descending for better packing
+    all.sort((a, b) => b.h - a.h);
+
+    const MW = 2048;
+    const P = 4;
+    let cx = P,
+      cy = P,
+      rh = 0,
+      fh = 0;
+    const pos = {};
+
+    all.forEach((s) => {
+      if (cx + s.w + P > MW) {
+        cy += rh + P;
+        cx = P;
+        rh = 0;
+      }
+      pos[s.key] = { x: cx, y: cy };
+      cx += s.w + P;
+      rh = Math.max(rh, s.h);
+      fh = Math.max(fh, cy + s.h + P);
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = MW;
+    canvas.height = fh;
+    const nc = canvas.getContext("2d");
+
+    all.forEach((s) => {
+      const p = pos[s.key];
+      nc.drawImage(s.canvas, p.x, p.y);
+    });
+
+    const newFrames = {};
+    all.forEach((s) => {
+      const p = pos[s.key];
+      newFrames[s.key] = {
+        frame: { x: p.x, y: p.y, w: s.w, h: s.h },
+        rotated: false,
+        trimmed: false,
+        spriteSourceSize: { x: 0, y: 0, w: s.w, h: s.h },
+        sourceSize: { w: s.w, h: s.h },
+      };
+    });
+
+    return { canvas, frames: newFrames };
+  }
+
+  // ── Status display ──
+
+  function setStatus(type, msg) {
+    statusEl.className = "";
+    if (type === "loading") {
+      statusEl.innerHTML = '<span class="spinner"></span>' + msg;
+    } else if (type === "error") {
+      statusEl.className = "error";
+      statusEl.textContent = msg;
+    } else if (type === "success") {
+      statusEl.className = "success";
+      statusEl.textContent = msg;
+    } else {
+      statusEl.textContent = msg;
+    }
+  }
+
+  // Resize overlay when window resizes
+  window.addEventListener("resize", () => {
+    if (sourceCanvas) syncCanvasSizes();
+  });
+})();

--- a/plugins/cordova-plugin-sprite-share/www/sprite-picker.css
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-picker.css
@@ -1,0 +1,221 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+body {
+  background: #1a1a2e;
+  color: #e0e0e0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* ── Top bar ── */
+
+#topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #16213e;
+  padding: 8px 12px;
+  min-height: 44px;
+  flex-shrink: 0;
+}
+
+.topbar-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+#close-btn {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  font-size: 28px;
+  line-height: 1;
+  padding: 4px 8px;
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+/* ── Canvas area ── */
+
+#canvas-wrap {
+  flex: 1;
+  position: relative;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  background: #0f0f23;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#source-canvas {
+  image-rendering: pixelated;
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+}
+
+#overlay-canvas {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  image-rendering: pixelated;
+  pointer-events: auto;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/* ── Thumbnails strip ── */
+
+#thumbs-strip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: #16213e;
+  min-height: 60px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-shrink: 0;
+}
+
+#thumbs-empty {
+  color: #666;
+  font-size: 12px;
+}
+
+.sp-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  border: 2px solid #0f3460;
+  border-radius: 4px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.sp-thumb.selected {
+  border-color: #00c853;
+}
+
+/* ── Controls ── */
+
+#controls {
+  background: #16213e;
+  padding: 8px 12px 10px;
+  flex-shrink: 0;
+  border-top: 1px solid #0f3460;
+}
+
+.ctrl-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.ctrl-row label {
+  min-width: 48px;
+  font-size: 12px;
+  color: #8899aa;
+}
+
+.ctrl-row select {
+  flex: 1;
+  background: #0f3460;
+  color: #e0e0e0;
+  border: 1px solid #1a4a8a;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 14px;
+  min-height: 44px;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.ctrl-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.btn {
+  flex: 1;
+  padding: 10px 8px;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 44px;
+  background: #0f3460;
+  color: #a0b0c0;
+}
+
+.btn-primary {
+  background: #00c853;
+  color: #1a1a2e;
+}
+
+.btn-primary:disabled {
+  background: #005f28;
+  color: #666;
+}
+
+.btn-danger {
+  background: #c62828;
+  color: #ffc0c0;
+}
+
+/* ── Status ── */
+
+#status {
+  background: #0f0f23;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #8899aa;
+  text-align: center;
+  flex-shrink: 0;
+  min-height: 28px;
+}
+
+#status.error {
+  color: #ff5555;
+}
+
+#status.success {
+  color: #00c853;
+}
+
+/* ── Spinner ── */
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #444;
+  border-top-color: #00c853;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/plugins/cordova-plugin-sprite-share/www/sprite-picker.html
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-picker.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<title>Sprite Share</title>
+<link rel="stylesheet" href="sprite-picker.css">
+</head>
+<body>
+  <!-- Top bar -->
+  <header id="topbar">
+    <span class="topbar-title">Sprite Share</span>
+    <button id="close-btn" title="Close">&times;</button>
+  </header>
+
+  <!-- Main canvas area (image + detection overlay) -->
+  <div id="canvas-wrap">
+    <canvas id="source-canvas"></canvas>
+    <canvas id="overlay-canvas"></canvas>
+  </div>
+
+  <!-- Thumbnail strip of selected sprites -->
+  <div id="thumbs-strip">
+    <span id="thumbs-empty">No sprites selected</span>
+  </div>
+
+  <!-- Controls panel -->
+  <div id="controls">
+    <div class="ctrl-row">
+      <label for="atlas-select">Atlas</label>
+      <select id="atlas-select">
+        <option value="game_asset">game_asset</option>
+        <option value="game_ui">game_ui</option>
+        <option value="title_ui">title_ui</option>
+      </select>
+    </div>
+    <div class="ctrl-row">
+      <label for="mode-select">Mode</label>
+      <select id="mode-select">
+        <option value="add">Add as new sprites</option>
+        <option value="replace">Replace existing frame</option>
+      </select>
+    </div>
+    <div class="ctrl-row" id="frame-row" style="display:none">
+      <label for="frame-select">Frame</label>
+      <select id="frame-select">
+        <option value="">-- Loading --</option>
+      </select>
+    </div>
+    <div class="ctrl-buttons">
+      <button id="save-btn" class="btn btn-primary">Save to Atlas</button>
+      <button id="select-all-btn" class="btn">Select All</button>
+      <button id="clear-btn" class="btn btn-danger">Clear</button>
+    </div>
+  </div>
+
+  <!-- Status bar -->
+  <div id="status">Waiting for image...</div>
+
+  <script src="sprite-detect.js"></script>
+  <script src="sprite-picker-app.js"></script>
+</body>
+</html>

--- a/plugins/cordova-plugin-sprite-share/www/sprite-share.js
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-share.js
@@ -1,0 +1,27 @@
+/**
+ * SpriteShare — Cordova JS module
+ *
+ * Provides a method for the main app to check whether the share Activity
+ * has saved a repacked atlas, so the game can reload it on resume.
+ */
+var SpriteShare = {
+  /**
+   * Check if a repacked atlas exists in internal storage.
+   * The share Activity saves repacked atlases with the _ prefix
+   * (e.g. _game_asset.png / _game_asset.json).
+   *
+   * @param {string} atlasName - e.g. "game_asset"
+   * @param {function} successCb - called with true/false
+   * @param {function} errorCb - called on failure
+   */
+  hasRepackedAtlas: function (atlasName, successCb, errorCb) {
+    // When running inside the main Cordova WebView, the Android bridge
+    // is not available (it's only injected in SpriteShareActivity's WebView).
+    // Instead we check via a simple XHR to the internal files path.
+    // For now, this is a no-op stub — the game's existing _game_asset
+    // detection in BootScene.js handles it via the ea.game_asset flag.
+    if (successCb) successCb(false);
+  }
+};
+
+module.exports = SpriteShare;


### PR DESCRIPTION
Adds a Cordova plugin (cordova-plugin-sprite-share) that registers the
app as an Android share target for images. When a user shares an image
from any app, a dedicated Activity opens with a touch-optimized sprite
picker UI that reuses the same flood-fill detection algorithm from the
Chrome Sprite Picker extension. Detected sprites are outlined with
bounding boxes, users can tap to select, then add or replace frames in
game atlases using the same row-pack repacking algorithm as the level
editor.

https://claude.ai/code/session_01A7eSYxupsiVmgFRBteJhsZ