### PR TITLE
Fix cordova prepare failing with git SSH auth error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,11 +96,11 @@ jobs:
 
       - name: Install Cordova plugins
         working-directory: cordova
-        run: cordova plugin add ../plugins/cordova-plugin-sprite-share
+        run: cordova plugin add ../plugins/cordova-plugin-sprite-share --nosave --nofetch
 
       - name: Prepare Cordova Android
         working-directory: cordova
-        run: cordova prepare android
+        run: cordova prepare android --nofetch
 
       - name: Force compileSdkVersion 35 for Cordova Android 14
         run: |


### PR DESCRIPTION
The cordova-plugin-sprite-share plugin was being saved to the project
config during `cordova plugin add`, causing `cordova prepare` to try
re-resolving it via npm. npm interpreted the local path as a GitHub
shorthand and attempted an SSH git clone, which fails in CI without
SSH keys.

Add --nosave --nofetch to the plugin add step and --nofetch to prepare
to prevent this re-resolution.

https://claude.ai/code/session_01UaroDVgpNWQRBHVtbCwoAE