### PR TITLE
Fix WebView crash from inlining large base64 image in evaluateJavascript

### DIFF
--- a/plugins/cordova-plugin-sprite-share/src/android/SpriteShareActivity.kt
+++ b/plugins/cordova-plugin-sprite-share/src/android/SpriteShareActivity.kt
@@ -52,11 +52,10 @@ class SpriteShareActivity : Activity() {
             webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
-                    // Pass the shared image to JS once the page is loaded
-                    sharedImageDataUrl?.let { dataUrl ->
-                        val escaped = dataUrl.replace("'", "\\'")
-                        view?.evaluateJavascript("receiveSharedImage('$escaped')", null)
-                    }
+                    // Signal JS to pull the image via the bridge — avoids
+                    // passing a multi-MB base64 string through evaluateJavascript
+                    // which crashes the WebView on large images.
+                    view?.evaluateJavascript("receiveSharedImage()", null)
                 }
             }
 
@@ -212,6 +211,16 @@ class SpriteShareActivity : Activity() {
             val jsonFile = File(filesDir, "assets/_${atlasName}.json")
             val pngFile = File(filesDir, "assets/img/_${atlasName}.png")
             return jsonFile.exists() && pngFile.exists()
+        }
+
+        /**
+         * Return the shared image as a base64 data URL.
+         * Called from JS instead of inlining the data in evaluateJavascript,
+         * which crashes the WebView for large images.
+         */
+        @JavascriptInterface
+        fun getSharedImage(): String {
+            return sharedImageDataUrl ?: ""
         }
 
         /**

--- a/plugins/cordova-plugin-sprite-share/www/sprite-picker-app.js
+++ b/plugins/cordova-plugin-sprite-share/www/sprite-picker-app.js
@@ -96,6 +96,17 @@
     setStatus("loading", "Running sprite detection...");
 
     try {
+      // Pull image data from the bridge if not passed directly — avoids
+      // the WebView crash that occurs when a multi-MB base64 string is
+      // inlined via evaluateJavascript.
+      if (!dataURL && typeof Android !== "undefined") {
+        dataURL = Android.getSharedImage();
+      }
+      if (!dataURL) {
+        setStatus("error", "No image data received.");
+        return;
+      }
+
       const img = new Image();
       img.src = dataURL;
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
The shared image (potentially 5-10MB+) was being passed as a string literal inside evaluateJavascript("receiveSharedImage('...')"), which crashes the WebView for large images.

Instead, onPageFinished now calls receiveSharedImage() with no args, and the JS side pulls the image data through the Android bridge via a new getSharedImage() method. The bridge interface handles large strings properly via IPC without the evaluateJavascript size limit.

https://claude.ai/code/session_01Lf8JGFSGbLHQM2ZSQEGeb1