### PR TITLE
Sync visualViewport safe-area fallbacks to prevent iOS top-UI clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
             font-display: swap;
         }
         html, body {
+            --safe-area-top-fallback: 0px;
+            --safe-area-bottom-fallback: 0px;
+            --safe-area-left-fallback: 0px;
+            --safe-area-right-fallback: 0px;
             margin: 0;
             padding: 0;
             width: 100%;
@@ -43,10 +47,10 @@
             align-items: center;
             justify-content: center;
             box-sizing: border-box;
-            padding-top: env(safe-area-inset-top, 0px);
-            padding-bottom: env(safe-area-inset-bottom, 0px);
-            padding-left: env(safe-area-inset-left, 0px);
-            padding-right: env(safe-area-inset-right, 0px);
+            padding-top: max(env(safe-area-inset-top, 0px), var(--safe-area-top-fallback));
+            padding-bottom: max(env(safe-area-inset-bottom, 0px), var(--safe-area-bottom-fallback));
+            padding-left: max(env(safe-area-inset-left, 0px), var(--safe-area-left-fallback));
+            padding-right: max(env(safe-area-inset-right, 0px), var(--safe-area-right-fallback));
         }
         #canvas canvas, #phaser-canvas canvas {
             image-rendering: pixelated;

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,33 @@ import { HitTester } from "./HitTester.js";
 
 let started = false;
 
+function syncViewportSafeAreaFallback() {
+    if (!document || !document.documentElement) { return; }
+
+    var rootStyle = document.documentElement.style;
+    var vv = window.visualViewport;
+    var top = 0;
+    var left = 0;
+    var right = 0;
+    var bottom = 0;
+
+    if (vv) {
+        top = Math.max(0, vv.offsetTop || 0);
+        left = Math.max(0, vv.offsetLeft || 0);
+        right = Math.max(0, window.innerWidth - (vv.offsetLeft + vv.width));
+        bottom = Math.max(0, window.innerHeight - (vv.offsetTop + vv.height));
+    }
+
+    rootStyle.setProperty("--safe-area-top-fallback", Math.round(top) + "px");
+    rootStyle.setProperty("--safe-area-left-fallback", Math.round(left) + "px");
+    rootStyle.setProperty("--safe-area-right-fallback", Math.round(right) + "px");
+    rootStyle.setProperty("--safe-area-bottom-fallback", Math.round(bottom) + "px");
+
+    if (typeof window.__fitCanvas === "function") {
+        window.__fitCanvas();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Orientation lock — requires fullscreen to be active on most mobile browsers
 // ---------------------------------------------------------------------------
@@ -101,6 +128,14 @@ export function fitCanvas() {
 
 window.addEventListener("resize", fitCanvas);
 window.__fitCanvas = fitCanvas;
+
+window.addEventListener("resize", syncViewportSafeAreaFallback);
+window.addEventListener("orientationchange", syncViewportSafeAreaFallback);
+if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", syncViewportSafeAreaFallback);
+    window.visualViewport.addEventListener("scroll", syncViewportSafeAreaFallback);
+}
+syncViewportSafeAreaFallback();
 
 // ---------------------------------------------------------------------------
 // Edge-swipe prevention


### PR DESCRIPTION
### Motivation
- Some iOS viewport states report incorrect or zero `env(safe-area-inset-*)` values which causes the game canvas and top UI to be clipped when the browser chrome shifts. 
- Provide a JS-driven fallback using `visualViewport` so the UI padding always accounts for the actual viewport offset.

### Description
- Add root CSS custom properties (`--safe-area-*-fallback`) and update container padding in `index.html` to use `max(env(...), var(--safe-area-*-fallback))` so the larger inset is honored. 
- Implement `syncViewportSafeAreaFallback()` in `src/main.js` that computes top/left/right/bottom insets from `window.visualViewport` and writes them to the CSS vars. 
- Wire the fallback sync to `resize`, `orientationchange`, and `visualViewport` `resize`/`scroll` events and call `window.__fitCanvas()` after updates so canvas scaling stays aligned. 
- Modified files: `index.html` and `src/main.js`.

### Testing
- Ran `node --check src/main.js` which succeeded. 
- Ran `node --check src/firebaseScores.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daba7e71b4832d8ce10a59fc68e596)