### PR TITLE
Atlas Manager: preserve saved overrides on load

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -3145,6 +3145,11 @@
                 const snap = await firebaseDb.ref(`${FIREBASE_LEVELS_PATH}/${name}`).once('value');
                 const d = snap.val();
                 if (!d) { alert(`"${name}" not found`); return false; }
+                // Reset per-level atlas customization state so overrides from a
+                // previously-loaded level don't leak into this one.
+                replacedFrames = {};
+                extraSprites = [];
+                customFrameKeys = new Set();
                 currentGrid = normalizeGrid(d.enemylist || []);
                 enemyData = (d.enemyData && typeof d.enemyData === 'object') ? d.enemyData : {};
                 bossData = (d.bossData && typeof d.bossData === 'object') ? d.bossData : {};
@@ -3159,13 +3164,11 @@
                 subTitleDataURL = d.subTitleDataURL || null;
                 titleStartTextDataURL = d.titleStartTextDataURL || null;
                 audioURLs = (d.customAudioURLs && typeof d.customAudioURLs === 'object') ? d.customAudioURLs : {};
-                // Firebase frames are LEVEL-SPECIFIC extras. The local atlas (loaded
-                // from disk — possibly the repacked `_game_asset.png`) is the baseline.
-                // For any Firebase key that also exists locally, the local version wins
-                // so repacks propagate into already-saved levels. Only truly-new keys
-                // are imported into extraSprites. Legacy full-atlas dumps therefore
-                // collapse to an empty customFrameKeys, and re-saving clears the stale
-                // Firebase atlas from the level record.
+                // Firebase atlasFrames holds this level's persisted customizations
+                // (replacements of local frames + newly-added sprites). Every entry
+                // must be imported so the Atlas Manager renders the customizations
+                // and the next save preserves them — otherwise editing a level after
+                // load drops every previously-saved override.
                 if (d.atlasImageDataURL && d.atlasFrames) {
                     const hasLocalAtlas = !!(atlasData && atlasData.frames && Object.keys(atlasData.frames).length > 0);
                     if (!hasLocalAtlas) {
@@ -3188,11 +3191,15 @@
                                 const key = fbKeyDecode(encKey);
                                 const f = frameData && frameData.frame;
                                 if (!f) continue;
-                                if (localFrames[key]) continue; // local wins
                                 const fc = document.createElement('canvas');
                                 fc.width = f.w; fc.height = f.h;
                                 fc.getContext('2d').drawImage(fbImg, f.x, f.y, f.w, f.h, 0, 0, f.w, f.h);
-                                if (!extraSprites.find(s => s.key === key)) {
+                                if (localFrames[key]) {
+                                    // Override of a frame that also exists in the local
+                                    // atlas: show it in the Atlas Manager as replaced.
+                                    replacedFrames[key] = { key, canvas: fc, w: f.w, h: f.h };
+                                } else if (!extraSprites.find(s => s.key === key)) {
+                                    // Brand-new sprite not present in the local atlas.
                                     extraSprites.push({ key, canvas: fc, w: f.w, h: f.h });
                                 }
                                 nextCustom.add(key);


### PR DESCRIPTION
loadFromFirebase was skipping every atlasFrames entry whose key already
existed in the local atlas ("local wins"). Because saveToFirebase only
writes customFrameKeys, every Firebase atlas frame IS a customization,
so skipping them made the Atlas Manager render the original local
frames and dropped prior overrides on the next save.

Import every Firebase atlas frame as a customization: existing-local
keys go into replacedFrames (so the Atlas Manager shows them with the
"replaced" outline) and new keys go into extraSprites. All keys land
in customFrameKeys so re-saving preserves the full merged set.

Also clear replacedFrames/extraSprites/customFrameKeys at load start
to prevent overrides from a previously-loaded level leaking into this
one.

https://claude.ai/code/session_01Wmg3ZBSEfLJ8gQv4ugYfm9