### PR TITLE
Fix apk-forge FileProvider resource path for Cordova

### DIFF
--- a/plugins/cordova-plugin-apk-forge/plugin.xml
+++ b/plugins/cordova-plugin-apk-forge/plugin.xml
@@ -36,7 +36,7 @@
         </config-file>
 
         <resource-file src="res/xml/apk_forge_paths.xml"
-                       target="app/src/main/res/xml/apk_forge_paths.xml" />
+                       target="res/xml/apk_forge_paths.xml" />
 
         <source-file src="src/android/ApkForgePlugin.kt"
                      target-dir="app/src/main/java/com/easierbycode/apkforge" />


### PR DESCRIPTION
Cordova's <resource-file target> for Android resources is relative to the platform res/ root, not the Android Studio project root. Using "app/src/main/res/xml/..." caused the file to land outside the AAPT search path; AAPT then failed with "xml/apk_forge_paths not found" when linking the manifest's FileProvider meta-data. Match the convention from cordova-plugin-camera: target="res/xml/...".

https://claude.ai/code/session_01W53ZTcmk7fqMgb6VRdTpBQ