### PR TITLE
Stop on-device manifest patcher from rewriting activity FQCN

### DIFF
--- a/plugins/cordova-plugin-apk-forge/src/android/AxmlPatcher.kt
+++ b/plugins/cordova-plugin-apk-forge/src/android/AxmlPatcher.kt
@@ -11,6 +11,17 @@ import java.io.File
  * into both the AXML attribute payload and the AXML string pool. Because
  * the replacement has the exact same UTF-16 byte length, no string-pool
  * offset table needs to be rewritten.
+ *
+ * Critical: only replace string-pool entries that are exactly the placeholder.
+ * The shell manifest also contains FQCN strings that *embed* the placeholder
+ * as a prefix — most importantly the activity's android:name
+ * ("<placeholder>.MainActivity"), and the FileProvider authority
+ * ("<placeholder>.apkforge.fileprovider"). Those strings must keep the
+ * placeholder package because the DEX class for the activity is compiled
+ * into the placeholder package and Android resolves the activity by class
+ * name at launch — rewriting that prefix would point Android at a class
+ * that doesn't exist and the forged APK would crash on open with
+ * ClassNotFoundException.
  */
 object AxmlPatcher {
 
@@ -24,33 +35,50 @@ object AxmlPatcher {
         val data = ZipRewriter.readEntry(apk, "AndroidManifest.xml")
             ?: throw IllegalStateException("AndroidManifest.xml missing")
         val padded = packageId.padEnd(PKG_LEN, '_')
-        val patched = replaceAllUtf16(data, PKG_PLACEHOLDER, padded)
+        val patched = replaceStandaloneUtf16(data, PKG_PLACEHOLDER, padded)
         ZipRewriter.replaceEntry(apk, "AndroidManifest.xml", patched)
     }
 
-    private fun replaceAllUtf16(data: ByteArray, find: String, replace: String): ByteArray {
+    private fun replaceStandaloneUtf16(data: ByteArray, find: String, replace: String): ByteArray {
         require(find.length == replace.length)
         val findBytes = find.toByteArray(Charsets.UTF_16LE)
         val replaceBytes = replace.toByteArray(Charsets.UTF_16LE)
         val out = data.copyOf()
-        var matches = 0
+        var standaloneMatches = 0
+        var skippedSubstringMatches = 0
         var i = 0
         while (i <= out.size - findBytes.size) {
             if (matchesAt(out, i, findBytes)) {
-                System.arraycopy(replaceBytes, 0, out, i, replaceBytes.size)
-                matches++
+                if (isStringPoolBoundary(out, i + findBytes.size)) {
+                    System.arraycopy(replaceBytes, 0, out, i, replaceBytes.size)
+                    standaloneMatches++
+                } else {
+                    skippedSubstringMatches++
+                }
                 i += findBytes.size
             } else {
                 i++
             }
         }
-        if (matches == 0) {
+        if (standaloneMatches == 0) {
             throw IllegalStateException(
-                "AXML placeholder not found — shell APK does not match expected format. " +
-                "Expected: '$find'"
+                "AXML placeholder not found as a standalone string — shell APK does " +
+                "not match expected format. Expected: '$find' " +
+                "(skippedSubstringMatches=$skippedSubstringMatches)"
             )
         }
         return out
+    }
+
+    /**
+     * AXML string-pool entries are NUL-terminated (UTF-16: 0x00 0x00). A match
+     * is the *whole* string only when the bytes immediately following it are
+     * the NUL terminator. Otherwise the match is the prefix of a longer string
+     * (e.g. "<placeholder>.MainActivity") and must be left intact.
+     */
+    private fun isStringPoolBoundary(data: ByteArray, end: Int): Boolean {
+        if (end + 1 >= data.size) return true
+        return data[end] == 0.toByte() && data[end + 1] == 0.toByte()
     }
 
     private fun matchesAt(data: ByteArray, idx: Int, needle: ByteArray): Boolean {

--- a/tools/build-shell-apk/index.js
+++ b/tools/build-shell-apk/index.js
@@ -134,7 +134,9 @@ function verifyPlaceholdersInApk(apkPath) {
         const hits = {
             manifestUtf16: 0, manifestUtf8: 0,
             arscUtf16: 0, arscUtf8: 0,
-            activityFqcnUtf16: 0, activityFqcnUtf8: 0
+            activityFqcnUtf16: 0, activityFqcnUtf8: 0,
+            standalonePkgUtf16: 0,
+            fqcnSurvivesSimulatedPatch: false
         };
         const samples = {};
         yauzl.open(apkPath, { lazyEntries: true }, function (err, zip) {
@@ -163,6 +165,11 @@ function verifyPlaceholdersInApk(apkPath) {
                                 Buffer.from(ACTIVITY_FQCN, "utf16le"));
                             hits.activityFqcnUtf8 += countOccurrences(buf,
                                 Buffer.from(ACTIVITY_FQCN, "utf8"));
+                            hits.standalonePkgUtf16 = countStandaloneUtf16(
+                                buf, PKG_PLACEHOLDER);
+                            hits.fqcnSurvivesSimulatedPatch =
+                                simulatedPatchPreservesFqcn(buf,
+                                    PKG_PLACEHOLDER, ACTIVITY_FQCN);
                         } else {
                             hits.arscUtf8 += countOccurrences(buf,
                                 Buffer.from(LABEL_PLACEHOLDER, "utf8"));
@@ -182,14 +189,66 @@ function verifyPlaceholdersInApk(apkPath) {
                 const labelFound = (hits.arscUtf16 + hits.arscUtf8) > 0;
                 const activityFqcnFound =
                     (hits.activityFqcnUtf16 + hits.activityFqcnUtf8) > 0;
+                const standaloneFound = hits.standalonePkgUtf16 > 0;
                 resolve({
-                    ok: pkgFound && labelFound && activityFqcnFound,
+                    ok: pkgFound && labelFound && activityFqcnFound &&
+                        standaloneFound && hits.fqcnSurvivesSimulatedPatch,
                     hits, samples,
                     activityFqcn: ACTIVITY_FQCN
                 });
             });
         });
     });
+}
+
+// Count UTF-16LE occurrences of `find` that are followed by a UTF-16 NUL
+// terminator (0x00 0x00) — i.e. a complete entry in the AXML string pool, not
+// a prefix of a longer string. Mirrors the Kotlin AxmlPatcher boundary check.
+function countStandaloneUtf16(haystack, find) {
+    const findBytes = Buffer.from(find, "utf16le");
+    let count = 0; let i = 0;
+    while ((i = haystack.indexOf(findBytes, i)) !== -1) {
+        const end = i + findBytes.length;
+        const followedByNul = end + 1 >= haystack.length ||
+            (haystack[end] === 0 && haystack[end + 1] === 0);
+        if (followedByNul) count++;
+        i += findBytes.length;
+    }
+    return count;
+}
+
+// Simulate the on-device manifest patch (AxmlPatcher) on the shell APK bytes
+// and confirm that the activity FQCN is still present unchanged afterwards.
+// This is the regression check for the launch crash: the FQCN must survive
+// the package-id rewrite, otherwise Android resolves the activity class to
+// <new-pkg>.MainActivity which doesn't exist in the DEX.
+function simulatedPatchPreservesFqcn(manifest, placeholder, fqcn) {
+    const probePkg = "com.example.probe.app.testlauncher.aaaaaaaaaaaa";
+    if (probePkg.length !== placeholder.length) {
+        throw new Error("probe package length mismatch (probe=" +
+            probePkg.length + ", placeholder=" + placeholder.length + ")");
+    }
+    const findBytes = Buffer.from(placeholder, "utf16le");
+    const replaceBytes = Buffer.from(probePkg, "utf16le");
+    const out = Buffer.from(manifest);
+    let i = 0; let standalone = 0;
+    while (i <= out.length - findBytes.length) {
+        if (out.slice(i, i + findBytes.length).equals(findBytes)) {
+            const end = i + findBytes.length;
+            const followedByNul = end + 1 >= out.length ||
+                (out[end] === 0 && out[end + 1] === 0);
+            if (followedByNul) {
+                replaceBytes.copy(out, i);
+                standalone++;
+            }
+            i += findBytes.length;
+        } else {
+            i++;
+        }
+    }
+    if (standalone === 0) return false;
+    const fqcnBytes = Buffer.from(fqcn, "utf16le");
+    return out.indexOf(fqcnBytes) !== -1;
 }
 
 function countOccurrences(haystack, needle) {
@@ -298,7 +357,13 @@ async function main() {
         console.error("Expected PKG_PLACEHOLDER:   " + PKG_PLACEHOLDER + " (len=" + PKG_PLACEHOLDER.length + ")");
         console.error("Expected LABEL_PLACEHOLDER: " + LABEL_PLACEHOLDER + " (len=" + LABEL_PLACEHOLDER.length + ")");
         console.error("Expected ACTIVITY_FQCN:    " + v.activityFqcn);
-        throw new Error("Placeholder strings not found in shell APK — manifest/arsc rewriting will fail at runtime, or the activity name is still relative and the forged APK will crash on launch");
+        if (v.hits.standalonePkgUtf16 === 0) {
+            console.error("No standalone (NUL-terminated) PKG_PLACEHOLDER occurrence in manifest — the on-device patcher would fail to find the package= attribute string.");
+        }
+        if (!v.hits.fqcnSurvivesSimulatedPatch) {
+            console.error("Simulated on-device patch destroyed the activity FQCN — the forged APK would crash on launch with ClassNotFoundException.");
+        }
+        throw new Error("Placeholder strings not found in shell APK — manifest/arsc rewriting will fail at runtime, or the simulated on-device patch mangles the activity FQCN and the forged APK would crash on launch");
     }
     console.log("Shell APK ready: " + outApk);
 }


### PR DESCRIPTION
The previous fix (PR #254) baked the fully-qualified placeholder activity
name `<placeholder>.MainActivity` into the shell manifest, on the theory
that "the patcher leaves it alone." The patcher actually does a global
UTF-16LE replace of the 47-char placeholder against the manifest bytes,
so it also overwrites the placeholder *inside* the 60-char FQCN — leaving
`<new-pkg>.MainActivity` in the manifest while the DEX class is still
compiled into `<placeholder>.MainActivity`. Android then resolves the
launch activity to a class that doesn't exist and the forged APK crashes
immediately on open with ClassNotFoundException.

Fix: in AxmlPatcher, only replace matches that are a complete entry in
the AXML string pool — i.e. where the bytes immediately following the
match are the UTF-16 NUL terminator (0x00 0x00). The standalone
`package=` value ends in NUL and gets patched; the FQCN's `.MainActivity`
continuation does not, so it survives intact. The same boundary check
also preserves the FileProvider authority `<placeholder>.apkforge.fileprovider`,
which was being silently mangled the same way.

Strengthen the shell-build verifier to catch this exact regression: it
now (a) confirms the placeholder appears as a NUL-terminated standalone
string at least once, and (b) simulates the on-device patch with a probe
package id and asserts the activity FQCN survives the simulated rewrite.
A broken patcher (or a shell with no standalone occurrence) fails the
build instead of shipping a crashing APK.

https://claude.ai/code/session_017DLNWUJLyPoeakkBgdCyfZ