### PR TITLE
Add on-device crash diagnostics for Android launch failures

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -166,7 +166,12 @@ module.exports = function (context) {
         "import android.os.Build",
         "import android.view.View",
         "import android.view.WindowInsets",
-        "import android.view.WindowInsetsController"
+        "import android.view.WindowInsetsController",
+        "import android.app.AlertDialog",
+        "import android.widget.TextView",
+        "import android.widget.ScrollView",
+        "import android.text.method.ScrollingMovementMethod",
+        "import java.io.File"
     ].join("\n");
 
     // Insert right after the existing CordovaActivity import line
@@ -175,8 +180,31 @@ module.exports = function (context) {
         "$1\n" + importsToAdd
     );
 
-    // ---- Add enterImmersiveMode() + onWindowFocusChanged() ---------------------
+    // ---- Add enterImmersiveMode() + onWindowFocusChanged() + showPreviousCrashIfAny() -
     const methodBlock = `
+    private fun showPreviousCrashIfAny() {
+        try {
+            val f = File(cacheDir, "last-crash.txt")
+            if (!f.exists()) return
+            val text = f.readText()
+            f.delete()
+            val tv = TextView(this).apply {
+                this.text = text
+                textSize = 10f
+                setPadding(24, 24, 24, 24)
+                setTextIsSelectable(true)
+                movementMethod = ScrollingMovementMethod()
+            }
+            val sv = ScrollView(this).apply { addView(tv) }
+            AlertDialog.Builder(this)
+                .setTitle("Previous launch crashed")
+                .setView(sv)
+                .setPositiveButton("Continue") { d, _ -> d.dismiss() }
+                .setCancelable(false)
+                .show()
+        } catch (_: Throwable) {}
+    }
+
     private fun enterImmersiveMode() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window.insetsController?.let { controller ->
@@ -204,10 +232,11 @@ module.exports = function (context) {
         }
     }`;
 
-    // Call enterImmersiveMode() right after loadUrl in onCreate
+    // Call enterImmersiveMode() right after loadUrl in onCreate, and surface any
+    // crash log written by ForgeApplication on the previous launch.
     src = src.replace(
         /(loadUrl\(launchUrl\))/,
-        "$1\n        enterImmersiveMode()"
+        "$1\n        enterImmersiveMode()\n        showPreviousCrashIfAny()"
     );
 
     // Insert methods before the final closing brace of the class

--- a/plugins/cordova-plugin-apk-forge/plugin.xml
+++ b/plugins/cordova-plugin-apk-forge/plugin.xml
@@ -24,7 +24,7 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <provider android:name="androidx.core.content.FileProvider"
+            <provider android:name="com.easierbycode.apkforge.ForgeFileProvider"
                       android:authorities="${applicationId}.apkforge.fileprovider"
                       android:exported="false"
                       android:grantUriPermissions="true"
@@ -35,10 +35,25 @@
             </provider>
         </config-file>
 
+        <!-- Diagnostic Application class: installs an UncaughtExceptionHandler in
+             attachBaseContext (i.e. before any ContentProvider.attachInfo runs)
+             so launch-time crashes are recorded to a file the user can read on
+             the device without ADB. -->
+        <edit-config file="AndroidManifest.xml"
+                     target="/manifest/application"
+                     mode="merge">
+            <application android:name="com.easierbycode.apkforge.ForgeApplication"
+                         xmlns:android="http://schemas.android.com/apk/res/android" />
+        </edit-config>
+
         <resource-file src="res/xml/apk_forge_paths.xml"
                        target="res/xml/apk_forge_paths.xml" />
 
         <source-file src="src/android/ApkForgePlugin.kt"
+                     target-dir="app/src/main/java/com/easierbycode/apkforge" />
+        <source-file src="src/android/ForgeApplication.kt"
+                     target-dir="app/src/main/java/com/easierbycode/apkforge" />
+        <source-file src="src/android/ForgeFileProvider.kt"
                      target-dir="app/src/main/java/com/easierbycode/apkforge" />
         <source-file src="src/android/ApkBuilder.kt"
                      target-dir="app/src/main/java/com/easierbycode/apkforge" />

--- a/plugins/cordova-plugin-apk-forge/src/android/ForgeApplication.kt
+++ b/plugins/cordova-plugin-apk-forge/src/android/ForgeApplication.kt
@@ -1,0 +1,74 @@
+package com.easierbycode.apkforge
+
+import android.app.Application
+import android.content.Context
+import android.os.Environment
+import android.util.Log
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Diagnostic Application class that installs an UncaughtExceptionHandler in
+ * attachBaseContext() — runs *before* ContentProvider.attachInfo, so it
+ * captures FileProvider/manifest-merge style crashes that would otherwise
+ * leave no visible trace on a device without ADB.
+ *
+ * The handler writes the stack trace to three locations (best-effort):
+ *   1. cacheDir/last-crash.txt                           (always writable)
+ *   2. getExternalFilesDir(null)/last-crash.txt          (visible to file managers)
+ *   3. /sdcard/Download/EvilInvadersForge/last-crash.txt (visible in Files app)
+ *
+ * MainActivity is patched (by hooks/after_prepare.js) to read #1 on the next
+ * launch and display it in a Dialog so the user can read the trace on-device.
+ */
+class ForgeApplication : Application() {
+
+    private var savedHandler: Thread.UncaughtExceptionHandler? = null
+
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        installCrashHandler(base)
+        Log.i(TAG, "ForgeApplication attached, crash handler installed")
+    }
+
+    private fun installCrashHandler(ctx: Context) {
+        savedHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try { writeCrashLog(ctx, thread, throwable) } catch (_: Throwable) {}
+            savedHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun writeCrashLog(ctx: Context, thread: Thread, throwable: Throwable) {
+        val sw = StringWriter()
+        val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+        sw.write("CRASH at $ts\n")
+        sw.write("Thread: ${thread.name}\n\n")
+        throwable.printStackTrace(PrintWriter(sw))
+        val text = sw.toString()
+        Log.e(TAG, text)
+
+        runCatching { File(ctx.cacheDir, CRASH_FILE).writeText(text) }
+
+        runCatching {
+            ctx.getExternalFilesDir(null)?.let { File(it, CRASH_FILE).writeText(text) }
+        }
+
+        runCatching {
+            @Suppress("DEPRECATION")
+            val downloads = File(Environment.getExternalStorageDirectory(),
+                "Download/EvilInvadersForge")
+            downloads.mkdirs()
+            File(downloads, CRASH_FILE).writeText(text)
+        }
+    }
+
+    companion object {
+        private const val TAG = "ForgeApplication"
+        const val CRASH_FILE = "last-crash.txt"
+    }
+}

--- a/plugins/cordova-plugin-apk-forge/src/android/ForgeFileProvider.kt
+++ b/plugins/cordova-plugin-apk-forge/src/android/ForgeFileProvider.kt
@@ -1,0 +1,30 @@
+package com.easierbycode.apkforge
+
+import android.content.Context
+import android.content.pm.ProviderInfo
+import android.util.Log
+import androidx.core.content.FileProvider
+
+/**
+ * FileProvider subclass that swallows attachInfo() failures so a misconfigured
+ * provider can't crash the entire app at launch. The forge plugin uses this in
+ * place of androidx.core.content.FileProvider so that even if @xml/apk_forge_paths
+ * is missing or malformed, the game APK still boots and surfaces the error
+ * via ForgeApplication's crash log instead of dying silently.
+ *
+ * The on-device APK builder won't work without a valid provider, but everything
+ * else (the actual game) does.
+ */
+class ForgeFileProvider : FileProvider() {
+    override fun attachInfo(context: Context, info: ProviderInfo) {
+        try {
+            super.attachInfo(context, info)
+        } catch (t: Throwable) {
+            Log.e(TAG, "attachInfo failed; forge installs will not work", t)
+        }
+    }
+
+    companion object {
+        private const val TAG = "ForgeFileProvider"
+    }
+}

--- a/src/phaser/boot-entry.js
+++ b/src/phaser/boot-entry.js
@@ -1,6 +1,22 @@
 // Boot entry point — bundled by esbuild into a single non-module script
 // for Cordova compatibility (WKWebView may not support ES module imports).
 
+// Visible boot-stage indicator — lets the user see on-device how far the JS
+// bundle progressed before any silent failure / blank canvas state.
+function bootMark(stage) {
+    try {
+        var el = document.getElementById("bootStage");
+        if (!el) {
+            el = document.createElement("div");
+            el.id = "bootStage";
+            el.style.cssText = "position:fixed;left:0;right:0;bottom:0;background:#003;color:#9bf;font:11px monospace;padding:2px 6px;z-index:9998;white-space:pre-wrap;";
+            (document.body || document.documentElement).appendChild(el);
+        }
+        el.textContent = "BOOT: " + stage;
+    } catch (_) {}
+}
+bootMark("entry");
+
 // Global error overlay for Cordova debugging
 window.onerror = function (msg, src, line, col, err) {
     var el = document.getElementById("loadError");
@@ -13,12 +29,22 @@ window.onerror = function (msg, src, line, col, err) {
     el.textContent += "JS: " + msg + " @ " + src + ":" + line + "\n";
 };
 window.onunhandledrejection = function (e) {
-    console.error("Unhandled rejection:", e.reason);
+    var msg = (e && e.reason && (e.reason.stack || e.reason.message)) || String(e && e.reason);
+    console.error("Unhandled rejection:", msg);
+    var el = document.getElementById("loadError");
+    if (!el) {
+        el = document.createElement("div");
+        el.id = "loadError";
+        el.style.cssText = "position:fixed;top:0;left:0;right:0;background:red;color:white;font:12px monospace;padding:4px;z-index:9999;max-height:30vh;overflow:auto;white-space:pre-wrap;";
+        document.body.appendChild(el);
+    }
+    el.textContent += "REJ: " + msg + "\n";
 };
 
 import { gameState } from "../gameState.js";
 import { initializeFirebaseScores } from "../firebaseScores.js";
 import { createPhaserGame } from "./PhaserGame.js";
+bootMark("imports loaded");
 
 function waitFor(ms) {
     return new Promise(function (resolve) { setTimeout(resolve, ms); });
@@ -32,9 +58,21 @@ try {
 } catch (e) {}
 
 // Initialize Firebase scores (race with timeout for fast boot)
+bootMark("firebase init");
 Promise.race([
     initializeFirebaseScores().catch(function () {}),
     waitFor(1500),
 ]).then(function () {
-    createPhaserGame();
+    bootMark("creating game");
+    try {
+        createPhaserGame();
+        bootMark("game created");
+        setTimeout(function () {
+            var el = document.getElementById("bootStage");
+            if (el && el.parentNode) el.parentNode.removeChild(el);
+        }, 5000);
+    } catch (e) {
+        bootMark("createPhaserGame threw: " + (e && e.message));
+        throw e;
+    }
 });


### PR DESCRIPTION
Phaser-game.apk has been crashing immediately on launch with no visible error. The earlier MainActivity FQCN fixes only address the *forged* level APK; the game APK itself is hitting something else (most likely FileProvider initialization, since that's the only new ContentProvider introduced by the apk-forge plugin and it runs *before* MainActivity).

Without ADB, we can't see logcat, so add three layers of on-device diagnostics that survive the next CI build:

1. ForgeApplication: a custom Application class registered via plugin.xml's edit-config. attachBaseContext() runs before any ContentProvider.attachInfo, so the UncaughtExceptionHandler installed here captures FileProvider crashes too. The handler writes the stack to cacheDir/last-crash.txt, getExternalFilesDir/last-crash.txt, and /sdcard/Download/EvilInvadersForge/last-crash.txt (best-effort).

2. ForgeFileProvider: subclass of androidx.core.content.FileProvider that swallows attachInfo() errors. If the provider is the one that's crashing, the app now boots anyway -- forge installs won't work, but the rest of the game does, and the captured stack reveals the real cause. Plugin.xml is updated to reference this subclass instead of FileProvider directly.

3. MainActivity patch (after_prepare.js): on launch, if cacheDir/last-crash.txt exists from a previous run, show its contents in a selectable AlertDialog with a Continue button, then delete it. Combined with #1 this gives the user readable crash output on the first relaunch after a crash, even with no ADB.

Plus a visible JS boot-stage indicator in src/phaser/boot-entry.js: a fixed-position "BOOT: <stage>" line at the bottom of the screen advances through entry / imports loaded / firebase init / creating game / game created. If the canvas stays black we can now see how far the JS bundle got. Unhandled rejections also feed the existing red error overlay.