### PR TITLE
Register ForgeApplication via after_prepare hook, not edit-config

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -132,6 +132,43 @@ function removeStaleSpriteShareJavaStub(context) {
     }
 }
 
+/**
+ * Register com.easierbycode.apkforge.ForgeApplication as the application
+ * class. This is done here (not via the apk-forge plugin's plugin.xml)
+ * because cordova-common rejects an <edit-config> on /manifest/application
+ * when another edit-config already targets /manifest/application/activity
+ * — it considers ancestor xpaths to overlap and refuses to merge.
+ *
+ * Idempotent: if android:name is already set on <application>, leaves it.
+ */
+function registerForgeApplication(platformRoot) {
+    const manifestPath = path.join(
+        platformRoot, "app", "src", "main", "AndroidManifest.xml"
+    );
+    if (!fs.existsSync(manifestPath)) return;
+
+    let xml = fs.readFileSync(manifestPath, "utf8");
+    if (xml.indexOf("ForgeApplication") !== -1) return;
+
+    const appOpenRe = /<application\b([^>]*)>/;
+    const m = xml.match(appOpenRe);
+    if (!m) {
+        console.warn("after_prepare hook: <application> tag not found in AndroidManifest.xml");
+        return;
+    }
+
+    const attrs = m[1];
+    if (/\bandroid:name\s*=/.test(attrs)) {
+        console.log("after_prepare hook: <application> already has android:name; leaving it alone");
+        return;
+    }
+
+    const replacement = '<application android:name="com.easierbycode.apkforge.ForgeApplication"' + attrs + '>';
+    xml = xml.replace(appOpenRe, replacement);
+    fs.writeFileSync(manifestPath, xml, "utf8");
+    console.log("after_prepare hook: registered ForgeApplication on <application> in AndroidManifest.xml");
+}
+
 module.exports = function (context) {
     // ── iOS: enable WKWebView remote inspection ─────────────────────
     patchIOSWebViewInspectable(context);
@@ -145,6 +182,9 @@ module.exports = function (context) {
         context.opts.projectRoot, "platforms", "android"
     );
     if (!fs.existsSync(platformRoot)) return;
+
+    // ── Android: register ForgeApplication on <application> ─────────
+    registerForgeApplication(platformRoot);
 
     const mainActivity = findFile(
         path.join(platformRoot, "app", "src"), "MainActivity.kt"

--- a/plugins/cordova-plugin-apk-forge/plugin.xml
+++ b/plugins/cordova-plugin-apk-forge/plugin.xml
@@ -35,16 +35,11 @@
             </provider>
         </config-file>
 
-        <!-- Diagnostic Application class: installs an UncaughtExceptionHandler in
-             attachBaseContext (i.e. before any ContentProvider.attachInfo runs)
-             so launch-time crashes are recorded to a file the user can read on
-             the device without ADB. -->
-        <edit-config file="AndroidManifest.xml"
-                     target="/manifest/application"
-                     mode="merge">
-            <application android:name="com.easierbycode.apkforge.ForgeApplication"
-                         xmlns:android="http://schemas.android.com/apk/res/android" />
-        </edit-config>
+        <!-- Diagnostic Application class (com.easierbycode.apkforge.ForgeApplication)
+             is registered on the <application> element by hooks/after_prepare.js
+             rather than via <edit-config> here, because cordova-common rejects
+             edit-config xpaths that overlap with an existing one (the project's
+             config.xml already targets /manifest/application/activity). -->
 
         <resource-file src="res/xml/apk_forge_paths.xml"
                        target="res/xml/apk_forge_paths.xml" />


### PR DESCRIPTION
The previous commit's edit-config in plugins/cordova-plugin-apk-forge/ plugin.xml broke the cordova prepare step in CI:

    Failed to install 'cordova-plugin-apk-forge': Error: There was a
    conflict trying to modify attributes with <edit-config> in plugin
    cordova-plugin-apk-forge. The conflicting plugin, undefined,
    already modified the same attributes.

cordova-common considers two <edit-config> blocks to overlap when one xpath is an ancestor of the other. The project's config.xml already edit-configs /manifest/application/activity, so registering an application-level android:name via /manifest/application is rejected even though the attributes don't actually overlap. The chained failure killed the entire deploy pipeline (cordova → web → pages-deploy), which is why phaser-game.apk disappeared from the GitHub Pages site.

Drop the edit-config and instead patch AndroidManifest.xml directly in hooks/after_prepare.js, which runs after all manifest merges. The hook adds android:name="...ForgeApplication" to the existing <application> element exactly once (idempotent: skips if android:name already set).