### PR TITLE
Allow Android split-screen (resizeableActivity=true)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -49,7 +49,7 @@
         <edit-config file="AndroidManifest.xml" target="/manifest/application/activity" mode="merge">
             <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
                       android:screenOrientation="portrait"
-                      android:resizeableActivity="false"
+                      android:resizeableActivity="true"
                       xmlns:android="http://schemas.android.com/apk/res/android" />
         </edit-config>
     </platform>


### PR DESCRIPTION
Flip the activity merge in config.xml from resizeableActivity="false" to "true" so Android lets 2028.ai participate in split-screen multi-window mode. The portrait orientation lock and configChanges list are unchanged -- Android keeps honoring screenOrientation when the activity is full screen and adapts the layout when split.