### PR TITLE
Always-on launch diagnostics: log every boot, show dialog every launch

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -210,8 +210,13 @@ module.exports = function (context) {
         "import android.app.AlertDialog",
         "import android.widget.TextView",
         "import android.widget.ScrollView",
+        "import android.widget.Toast",
         "import android.text.method.ScrollingMovementMethod",
-        "import java.io.File"
+        "import android.os.Environment",
+        "import java.io.File",
+        "import java.text.SimpleDateFormat",
+        "import java.util.Date",
+        "import java.util.Locale"
     ].join("\n");
 
     // Insert right after the existing CordovaActivity import line
@@ -220,28 +225,70 @@ module.exports = function (context) {
         "$1\n" + importsToAdd
     );
 
-    // ---- Add enterImmersiveMode() + onWindowFocusChanged() + showPreviousCrashIfAny() -
+    // ---- Add enterImmersiveMode() + onWindowFocusChanged() + showDiagnostics() ----
     const methodBlock = `
-    private fun showPreviousCrashIfAny() {
+    private fun appendActivityDiagLine(marker: String) {
         try {
-            val f = File(cacheDir, "last-crash.txt")
-            if (!f.exists()) return
-            val text = f.readText()
-            f.delete()
-            val tv = TextView(this).apply {
-                this.text = text
-                textSize = 10f
-                setPadding(24, 24, 24, 24)
-                setTextIsSelectable(true)
-                movementMethod = ScrollingMovementMethod()
+            val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+            val line = "[\$ts] \$marker\\n"
+            File(cacheDir, "launch-log.txt").appendText(line)
+            try {
+                getExternalFilesDir(null)?.let { File(it, "launch-log.txt").appendText(line) }
+            } catch (_: Throwable) {}
+            try {
+                @Suppress("DEPRECATION")
+                val dl = File(Environment.getExternalStorageDirectory(), "Download/EvilInvadersForge")
+                dl.mkdirs()
+                File(dl, "launch-log.txt").appendText(line)
+            } catch (_: Throwable) {}
+        } catch (_: Throwable) {}
+    }
+
+    private fun showDiagnostics() {
+        try {
+            // Always-visible Toast: confirms MainActivity reached this point.
+            Toast.makeText(this, "MainActivity OK (forge diag)", Toast.LENGTH_LONG).show()
+
+            val crash = File(cacheDir, "last-crash.txt")
+            val log = File(cacheDir, "launch-log.txt")
+            val hasCrash = crash.exists()
+            val hasLog = log.exists()
+            if (!hasCrash && !hasLog) return
+
+            val sb = StringBuilder()
+            if (hasCrash) {
+                sb.append("=== LAST CRASH ===\\n").append(crash.readText()).append("\\n\\n")
             }
-            val sv = ScrollView(this).apply { addView(tv) }
-            AlertDialog.Builder(this)
-                .setTitle("Previous launch crashed")
-                .setView(sv)
-                .setPositiveButton("Continue") { d, _ -> d.dismiss() }
-                .setCancelable(false)
-                .show()
+            if (hasLog) {
+                sb.append("=== LAUNCH LOG (most recent) ===\\n").append(log.readText())
+            }
+            val text = sb.toString()
+
+            // Post to UI thread with a small delay so the dialog has a chance to
+            // render even if loadUrl() triggers a fast follow-on crash.
+            window.decorView.postDelayed({
+                try {
+                    val tv = TextView(this).apply {
+                        this.text = text
+                        textSize = 10f
+                        setPadding(24, 24, 24, 24)
+                        setTextIsSelectable(true)
+                        movementMethod = ScrollingMovementMethod()
+                    }
+                    val sv = ScrollView(this).apply { addView(tv) }
+                    AlertDialog.Builder(this)
+                        .setTitle(if (hasCrash) "Previous launch crashed" else "Forge diagnostics")
+                        .setView(sv)
+                        .setPositiveButton("Continue") { d, _ -> d.dismiss() }
+                        .setNegativeButton("Clear logs") { d, _ ->
+                            try { crash.delete() } catch (_: Throwable) {}
+                            try { log.delete() } catch (_: Throwable) {}
+                            d.dismiss()
+                        }
+                        .setCancelable(false)
+                        .show()
+                } catch (_: Throwable) {}
+            }, 300L)
         } catch (_: Throwable) {}
     }
 
@@ -272,11 +319,12 @@ module.exports = function (context) {
         }
     }`;
 
-    // Call enterImmersiveMode() right after loadUrl in onCreate, and surface any
-    // crash log written by ForgeApplication on the previous launch.
+    // Call enterImmersiveMode() and the diag dialog right after loadUrl in
+    // onCreate, plus log activity start/stop transitions to launch-log.txt so
+    // we can tell from the file alone how far the process got.
     src = src.replace(
         /(loadUrl\(launchUrl\))/,
-        "$1\n        enterImmersiveMode()\n        showPreviousCrashIfAny()"
+        'appendActivityDiagLine("ACTIVITY_PRE_LOAD")\n        $1\n        appendActivityDiagLine("ACTIVITY_POST_LOAD")\n        enterImmersiveMode()\n        showDiagnostics()'
     );
 
     // Insert methods before the final closing brace of the class

--- a/plugins/cordova-plugin-apk-forge/src/android/ForgeApplication.kt
+++ b/plugins/cordova-plugin-apk-forge/src/android/ForgeApplication.kt
@@ -2,6 +2,7 @@ package com.easierbycode.apkforge
 
 import android.app.Application
 import android.content.Context
+import android.os.Build
 import android.os.Environment
 import android.util.Log
 import java.io.File
@@ -12,18 +13,20 @@ import java.util.Date
 import java.util.Locale
 
 /**
- * Diagnostic Application class that installs an UncaughtExceptionHandler in
- * attachBaseContext() — runs *before* ContentProvider.attachInfo, so it
- * captures FileProvider/manifest-merge style crashes that would otherwise
- * leave no visible trace on a device without ADB.
+ * Diagnostic Application class. Two responsibilities:
  *
- * The handler writes the stack trace to three locations (best-effort):
- *   1. cacheDir/last-crash.txt                           (always writable)
- *   2. getExternalFilesDir(null)/last-crash.txt          (visible to file managers)
- *   3. /sdcard/Download/EvilInvadersForge/last-crash.txt (visible in Files app)
+ *   1) Append a "boot ping" line to a launch log on every process start so the
+ *      user can confirm — even on a device with no ADB — whether ForgeApplication
+ *      is being loaded at all. The log is written to several locations so at
+ *      least one is reachable from a stock Files app.
  *
- * MainActivity is patched (by hooks/after_prepare.js) to read #1 on the next
- * launch and display it in a Dialog so the user can read the trace on-device.
+ *   2) Install an UncaughtExceptionHandler in attachBaseContext (runs *before*
+ *      ContentProvider.attachInfo, so it captures FileProvider/manifest-merge
+ *      style crashes that would otherwise leave no trace) and persist the
+ *      stack trace to the same locations.
+ *
+ * MainActivity (patched by hooks/after_prepare.js) reads these files on every
+ * launch and shows them in a Dialog so the user has a visible record without ADB.
  */
 class ForgeApplication : Application() {
 
@@ -31,8 +34,14 @@ class ForgeApplication : Application() {
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
+        appendDiagLine(base, "APP_ATTACH pid=${android.os.Process.myPid()} api=${Build.VERSION.SDK_INT}")
         installCrashHandler(base)
         Log.i(TAG, "ForgeApplication attached, crash handler installed")
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        appendDiagLine(this, "APP_CREATE")
     }
 
     private fun installCrashHandler(ctx: Context) {
@@ -47,7 +56,8 @@ class ForgeApplication : Application() {
         val sw = StringWriter()
         val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
         sw.write("CRASH at $ts\n")
-        sw.write("Thread: ${thread.name}\n\n")
+        sw.write("Thread: ${thread.name}\n")
+        sw.write("Process: ${android.os.Process.myPid()}\n\n")
         throwable.printStackTrace(PrintWriter(sw))
         val text = sw.toString()
         Log.e(TAG, text)
@@ -67,8 +77,41 @@ class ForgeApplication : Application() {
         }
     }
 
+    /**
+     * Append a single timestamped line to launch-log.txt in three locations
+     * (best-effort; any can fail without affecting the others). Keeps the
+     * tail of the file under MAX_LOG_BYTES so it doesn't grow unbounded.
+     */
+    private fun appendDiagLine(ctx: Context, marker: String) {
+        val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
+        val line = "[$ts] $marker\n"
+
+        runCatching { appendCapped(File(ctx.cacheDir, LAUNCH_LOG), line) }
+        runCatching {
+            ctx.getExternalFilesDir(null)?.let { appendCapped(File(it, LAUNCH_LOG), line) }
+        }
+        runCatching {
+            @Suppress("DEPRECATION")
+            val downloads = File(Environment.getExternalStorageDirectory(),
+                "Download/EvilInvadersForge")
+            downloads.mkdirs()
+            appendCapped(File(downloads, LAUNCH_LOG), line)
+        }
+    }
+
+    private fun appendCapped(f: File, text: String) {
+        if (f.exists() && f.length() > MAX_LOG_BYTES) {
+            // Trim to last half so we keep recent history
+            val keep = f.readText().takeLast(MAX_LOG_BYTES.toInt() / 2)
+            f.writeText(keep)
+        }
+        f.appendText(text)
+    }
+
     companion object {
         private const val TAG = "ForgeApplication"
         const val CRASH_FILE = "last-crash.txt"
+        const val LAUNCH_LOG = "launch-log.txt"
+        private const val MAX_LOG_BYTES = 64L * 1024L
     }
 }


### PR DESCRIPTION
## Summary

The previous diagnostic patch only fired the dialog when `last-crash.txt` existed, so a crash that kills the process *before* `ForgeApplication`'s `UncaughtExceptionHandler` is installed (or any non-JVM crash) leaves no trace. APK still crashes with no error displayed even after the earlier fixes shipped to GitHub Pages.

This makes the diagnostics unmissable so we can localize where the boot dies — even on a device with no ADB.

- `ForgeApplication` appends `APP_ATTACH` (in `attachBaseContext`) and `APP_CREATE` (in `onCreate`) to `launch-log.txt` in three locations (cacheDir, `getExternalFilesDir(null)`, `/sdcard/Download/EvilInvadersForge/`). File is capped at 64 KiB and trimmed in place.
- MainActivity (patched by `after_prepare.js`) appends `ACTIVITY_PRE_LOAD` before `loadUrl(launchUrl)` and `ACTIVITY_POST_LOAD` after it.
- Always-visible `Toast` ("MainActivity OK (forge diag)") fires every launch.
- `showDiagnostics()` replaces `showPreviousCrashIfAny()`: always shows the dialog when either log exists, posted to the UI thread with a 300 ms delay so it survives a fast follow-on WebView crash. Adds a "Clear logs" button.

## How to read the launch log after install + crash

Open Files → `Download/EvilInvadersForge/launch-log.txt`:

- **empty / file missing** → `ForgeApplication` is not loaded (DEX or manifest patch failure)
- `APP_ATTACH` only → `Application.onCreate` died
- missing `ACTIVITY_PRE_LOAD` → `super.onCreate` / `loadConfig` died
- missing `ACTIVITY_POST_LOAD` → `loadUrl` crashed synchronously
- all four entries → JVM is fine; the "crash" is really a black WebView (JS bundle failed)

## Test plan

- [ ] Merge → CI rebuilds `phaser-game.apk` and republishes to GitHub Pages
- [ ] Install fresh APK; on launch, confirm the Toast appears
- [ ] Trigger another launch; confirm the diagnostic dialog appears with launch log contents
- [ ] If a crash still occurs, capture `Download/EvilInvadersForge/launch-log.txt` and `last-crash.txt` to localize the failure point

https://claude.ai/code/session_01QKetPKivdrQwE23ej4vMjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKetPKivdrQwE23ej4vMjC)_