### PR TITLE
Lazy-load apk-forge; MediaStore launch log; attachBaseContext marker + early Toast

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -203,7 +203,12 @@ module.exports = function (context) {
 
     // ---- Add required imports --------------------------------------------------
     const importsToAdd = [
+        "import android.content.ContentUris",
+        "import android.content.ContentValues",
+        "import android.content.Context",
+        "import android.net.Uri",
         "import android.os.Build",
+        "import android.provider.MediaStore",
         "import android.view.View",
         "import android.view.WindowInsets",
         "import android.view.WindowInsetsController",
@@ -230,21 +235,90 @@ module.exports = function (context) {
 
     // ---- Add enterImmersiveMode() + onWindowFocusChanged() + showDiagnostics() ----
     const methodBlock = `
-    private fun appendActivityDiagLine(marker: String) {
+    private val DIAG_DOWNLOAD_NAME = "evilinvaders-launch-log.txt"
+    private val DIAG_CRASH_DOWNLOAD_NAME = "evilinvaders-last-crash.txt"
+
+    private fun diagAppendCtx(ctx: Context, marker: String) {
         try {
             val ts = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())
             val line = "[\$ts] \$marker\\n"
-            try { File(cacheDir, "launch-log.txt").appendText(line) } catch (_: Throwable) {}
+
+            // 1. App cache (always works, hidden from user but used by showDiagnostics)
+            try { File(ctx.cacheDir, "launch-log.txt").appendText(line) } catch (_: Throwable) {}
+
+            // 2. App external files dir (always works; user-visible only with adb /
+            // third-party file manager because Android 11+ Files app blocks it)
             try {
-                getExternalFilesDir(null)?.let { File(it, "launch-log.txt").appendText(line) }
+                ctx.getExternalFilesDir(null)?.let { File(it, "launch-log.txt").appendText(line) }
             } catch (_: Throwable) {}
-            try {
-                @Suppress("DEPRECATION")
-                val dl = File(Environment.getExternalStorageDirectory(), "Download/EvilInvadersForge")
-                dl.mkdirs()
-                File(dl, "launch-log.txt").appendText(line)
-            } catch (_: Throwable) {}
+
+            // 3. Public Downloads via MediaStore on API 29+ (the only place a user can
+            // actually find it from a stock Files app on Android 11+). On 28 and below
+            // we fall back to the legacy direct-file path.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                try { mediaStoreAppend(ctx, DIAG_DOWNLOAD_NAME, line) } catch (_: Throwable) {}
+            } else {
+                try {
+                    @Suppress("DEPRECATION")
+                    val dl = File(Environment.getExternalStorageDirectory(), "Download/EvilInvadersForge")
+                    dl.mkdirs()
+                    File(dl, "launch-log.txt").appendText(line)
+                } catch (_: Throwable) {}
+            }
         } catch (_: Throwable) {}
+    }
+
+    private fun appendActivityDiagLine(marker: String) = diagAppendCtx(this, marker)
+
+    private fun mediaStoreAppend(ctx: Context, displayName: String, text: String) {
+        val resolver = ctx.contentResolver
+        val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+        val projection = arrayOf(MediaStore.Downloads._ID)
+        val selection = MediaStore.Downloads.DISPLAY_NAME + " = ?"
+        val args = arrayOf(displayName)
+
+        var existing: Uri? = null
+        try {
+            resolver.query(collection, projection, selection, args, null)?.use { c ->
+                if (c.moveToFirst()) existing = ContentUris.withAppendedId(collection, c.getLong(0))
+            }
+        } catch (_: Throwable) {}
+
+        val target = existing ?: run {
+            val values = ContentValues().apply {
+                put(MediaStore.Downloads.DISPLAY_NAME, displayName)
+                put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+                put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            }
+            resolver.insert(collection, values) ?: return
+        }
+        resolver.openOutputStream(target, "wa")?.use { it.write(text.toByteArray()) }
+    }
+
+    private fun mediaStoreOverwrite(ctx: Context, displayName: String, text: String) {
+        val resolver = ctx.contentResolver
+        val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+        val projection = arrayOf(MediaStore.Downloads._ID)
+        val selection = MediaStore.Downloads.DISPLAY_NAME + " = ?"
+        val args = arrayOf(displayName)
+
+        var existing: Uri? = null
+        try {
+            resolver.query(collection, projection, selection, args, null)?.use { c ->
+                if (c.moveToFirst()) existing = ContentUris.withAppendedId(collection, c.getLong(0))
+            }
+        } catch (_: Throwable) {}
+
+        val target = existing ?: run {
+            val values = ContentValues().apply {
+                put(MediaStore.Downloads.DISPLAY_NAME, displayName)
+                put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+                put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS)
+            }
+            resolver.insert(collection, values) ?: return
+        }
+        // "wt" truncates and writes
+        resolver.openOutputStream(target, "wt")?.use { it.write(text.toByteArray()) }
     }
 
     private fun installCrashHandler() {
@@ -260,12 +334,16 @@ module.exports = function (context) {
                     Log.e("MainActivityCrash", text)
                     try { File(cacheDir, "last-crash.txt").writeText(text) } catch (_: Throwable) {}
                     try { getExternalFilesDir(null)?.let { File(it, "last-crash.txt").writeText(text) } } catch (_: Throwable) {}
-                    try {
-                        @Suppress("DEPRECATION")
-                        val dl = File(Environment.getExternalStorageDirectory(), "Download/EvilInvadersForge")
-                        dl.mkdirs()
-                        File(dl, "last-crash.txt").writeText(text)
-                    } catch (_: Throwable) {}
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        try { mediaStoreOverwrite(this, DIAG_CRASH_DOWNLOAD_NAME, text) } catch (_: Throwable) {}
+                    } else {
+                        try {
+                            @Suppress("DEPRECATION")
+                            val dl = File(Environment.getExternalStorageDirectory(), "Download/EvilInvadersForge")
+                            dl.mkdirs()
+                            File(dl, "last-crash.txt").writeText(text)
+                        } catch (_: Throwable) {}
+                    }
                 } catch (_: Throwable) {}
                 previous?.uncaughtException(thread, throwable)
             }
@@ -345,16 +423,29 @@ module.exports = function (context) {
         if (hasFocus) {
             enterImmersiveMode()
         }
+    }
+
+    override fun attachBaseContext(newBase: Context) {
+        // Earliest hook in the Activity lifecycle. Runs before super.onCreate,
+        // before Cordova bootstrap, before plugin instantiation. If MAIN_ATTACH
+        // never appears in evilinvaders-launch-log.txt (Files app -> Downloads),
+        // the crash is happening before MainActivity even gets constructed —
+        // probably a manifest / dex-load problem. If MAIN_ATTACH appears but
+        // ACTIVITY_PRE_SUPER does not, super.attachBaseContext is the killer.
+        // If ACTIVITY_PRE_SUPER appears but POST_SUPER does not, super.onCreate
+        // (i.e. CordovaActivity bootstrap) is the killer.
+        try { diagAppendCtx(newBase, "MAIN_ATTACH") } catch (_: Throwable) {}
+        super.attachBaseContext(newBase)
+        try { diagAppendCtx(newBase, "MAIN_ATTACH_DONE") } catch (_: Throwable) {}
     }`;
 
-    // Insert ACTIVITY_ENTER + crash handler at the very start of onCreate (right
-    // after super.onCreate). This proves the activity reached our patched code
-    // even if the WebView load triggers a fast follow-on crash. Then surround
-    // loadUrl with PRE_LOAD/POST_LOAD markers so the file alone tells us how
-    // far the boot got.
+    // Wrap super.onCreate with PRE/POST markers and Toast so the user has
+    // immediate visible confirmation that MainActivity reached this point even
+    // if loadUrl triggers a fast follow-on crash. Then surround loadUrl with
+    // PRE_LOAD/POST_LOAD markers.
     src = src.replace(
         /(super\.onCreate\([^)]*\))/,
-        '$1\n        appendActivityDiagLine("ACTIVITY_ENTER")\n        installCrashHandler()'
+        'appendActivityDiagLine("ACTIVITY_PRE_SUPER")\n        $1\n        appendActivityDiagLine("ACTIVITY_POST_SUPER")\n        try { Toast.makeText(this, "MainActivity OK (forge diag)", Toast.LENGTH_LONG).show() } catch (_: Throwable) {}\n        installCrashHandler()'
     );
     src = src.replace(
         /(loadUrl\(launchUrl\))/,

--- a/plugins/cordova-plugin-apk-forge/plugin.xml
+++ b/plugins/cordova-plugin-apk-forge/plugin.xml
@@ -14,7 +14,15 @@
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="ApkForge">
                 <param name="android-package" value="com.easierbycode.apkforge.ApkForgePlugin" />
-                <param name="onload" value="true" />
+                <!-- Lazy-load: the plugin is instantiated on first JS call,
+                     not at app startup. With onload="true" the plugin class
+                     was loaded during super.onCreate() of MainActivity, and
+                     any verification / class-resolution failure (e.g. a
+                     transitive missing dep on apksig / bouncycastle) would
+                     crash the entire game APK before our diagnostics could
+                     run. Lazy loading isolates that risk to the moment the
+                     user actually triggers a forge build. -->
+                <param name="onload" value="false" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
## Summary

After PR #260 shipped the user reports the same symptom: "2028.ai keeps stopping" with **no Toast** and an **empty `Download/EvilInvadersForge`** folder. Two probable reasons we'd see exactly that combination:

1. The earlier diagnostic wrote `launch-log.txt` via direct `File.appendText("/sdcard/Download/...")`. Apps targeting SDK 30+ **can't** write to public Downloads via direct file paths — the call silently fails. So the file would never appear even if `MainActivity` did reach the diag code. **Switch to MediaStore** on API 29+ (writes a flat `evilinvaders-launch-log.txt` into MediaStore Downloads, which the stock Files app *can* see).
2. `ApkForgePlugin` still had `onload="true"` in `res/xml/config.xml`, which causes Cordova to **instantiate the plugin during `super.onCreate()`** — i.e. loads the class before any of our diagnostic code runs. Any transitive class-resolution failure (apksig / bouncycastle) would crash the app at exactly the observed point. **Switch to `onload="false"`** so the class is only loaded when JS first calls a method.

Plus tighten the activity diagnostics:

- Override `attachBaseContext(newBase)` and write `MAIN_ATTACH` / `MAIN_ATTACH_DONE` markers around `super.attachBaseContext`. Earliest hook in the Activity lifecycle, before `super.onCreate` / Cordova bootstrap. If `MAIN_ATTACH` never appears, the crash is even earlier than MainActivity itself (manifest / dex load).
- Wrap `super.onCreate` with `ACTIVITY_PRE_SUPER` / `ACTIVITY_POST_SUPER` and fire the "MainActivity OK" Toast **immediately** after `super.onCreate` returns — so the user has a visible signal of activity-reached even if `loadConfig` / `loadUrl` crashes synchronously.

The launch log now lands in three places:
- `<cacheDir>/launch-log.txt` (always works, hidden)
- `<getExternalFilesDir>/launch-log.txt` (always works, hidden by Files app on 11+)
- **Downloads/evilinvaders-launch-log.txt** (MediaStore, user-visible)

## Test plan

- [ ] Merge → CI rebuilds `phaser-game.apk`
- [ ] Reinstall, launch
- [ ] Open Files → Downloads → look for `evilinvaders-launch-log.txt`
  - **Has `MAIN_ATTACH` only** → crash is in `super.attachBaseContext`
  - **Has `MAIN_ATTACH_DONE` but no `ACTIVITY_PRE_SUPER`** → super weirdness between attach and onCreate
  - **Has `ACTIVITY_PRE_SUPER` but no `ACTIVITY_POST_SUPER`** → `super.onCreate` (CordovaActivity bootstrap) is the killer
  - **Has all four + Toast** → JVM is fine; "crash" is JS-layer / WebView; check `evilinvaders-last-crash.txt` if present
  - **File doesn't exist at all** → MainActivity is never instantiated; manifest / dex load issue

https://claude.ai/code/session_01QKetPKivdrQwE23ej4vMjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKetPKivdrQwE23ej4vMjC)_