### PR TITLE
Reinstate ?boss=goki Akuma cheat

### DIFF
--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -726,6 +726,18 @@ export class BootScene extends Phaser.Scene {
         var stageParam = readStageParam();
         var bossRush = readBossRushParam();
 
+        // ?boss=goki forces the goki boss: pin stage 3 (unless ?stage says
+        // otherwise) and jump straight to the boss via the bossRush path.
+        var forceBoss = null;
+        try {
+            forceBoss = new URLSearchParams(window.location.search).get("boss");
+        } catch (e) {}
+        if (forceBoss === "goki") {
+            gameState.forceBossName = "goki";
+            if (stageParam == null) stageParam = 3;
+            bossRush = true;
+        }
+
         var nextSceneKey = "PhaserTitleScene";
         if (editorPlay && recipe) {
             primeGameStateForStage(recipe, editorPlay.stageId);

--- a/src/phaser/TitleScene.js
+++ b/src/phaser/TitleScene.js
@@ -418,6 +418,7 @@ export class PhaserTitleScene extends Phaser.Scene {
         gameState.continueCnt = 0;
         gameState.akebonoCnt = 0;
         gameState.shortFlg = false;
+        gameState.forceBossName = null;
 
         var game = this.game;
         setTimeout(function () {

--- a/src/phaser/game-objects/Boss.js
+++ b/src/phaser/game-objects/Boss.js
@@ -56,8 +56,9 @@ export function bossAdd(scene) {
     scene.gokiFlg = false;
     scene.bossIsGoki = false;
 
-    // spBoss: at stageId 3 with 0 continues, BossGoki replaces BossVega
-    var isGokiStage = stageId === 3 && Number(gameState.continueCnt || 0) === 0;
+    // spBoss: at stageId 3 with 0 continues, BossGoki replaces BossVega.
+    // forceBossName ("goki" via ?boss=goki) keeps goki even after a continue.
+    var isGokiStage = stageId === 3 && Number(gameState.continueCnt || 0) === 0 || gameState.forceBossName === "goki" && stageId === 3;
     if (isGokiStage) {
         scene.gokiFlg = true;
     }


### PR DESCRIPTION
## Summary
- `?boss=goki` URL param pins stage 3 and jumps straight to the boss fight via the bossRush path
- `gameState.forceBossName = "goki"` keeps BossGoki replacing BossVega even after a continue (normally Goki only appears with 0 continues)
- Title-screen game start resets `forceBossName` so the cheat doesn't leak into normal runs

## Verification
Booted `/phaser-game?lowmode=1&level=__nope__&boss=goki` via preview: `forceBossName==="goki"`, `stageId===3`, `shortFlg===true`; with `continueCnt=1`, `gokiFlg` stayed true and the full Goki takeover sequence ran (`bossIsGoki===true`, `bossName==="goki"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)