### PR TITLE
Report why the Dezaemon importer failed to load instead of guessing

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -11,16 +11,33 @@
         // Dezaemon 2 importer — the same ESM modules the Node CLI + tests use
         // (tools/dezaemon-import). Module scripts are deferred, so
         // window.Dezaemon exists before any user interaction; entry points
-        // still guard on it in case the import fails (e.g. file:// serving).
-        import * as bupSource from "./tools/dezaemon-import/lib/bup-source.js";
-        import * as bupParse from "./tools/dezaemon-import/lib/bup-parse.js";
-        import * as payloadTable from "./tools/dezaemon-import/lib/payload-table.js";
-        import { decodeSave } from "./tools/dezaemon-import/lib/decode/index.js";
-        import * as mapToGame from "./tools/dezaemon-import/lib/map-to-game.js";
-        import { packShelf } from "./tools/dezaemon-import/lib/atlas-pack.js";
-        import { validateGameJson } from "./tools/dezaemon-import/lib/game-schema.js";
-        window.Dezaemon = Object.assign({}, bupSource, bupParse, payloadTable, mapToGame,
-            { decodeSave, packShelf, validateGameJson });
+        // still guard on it in case the import fails.
+        //
+        // Imports are dynamic so a failure is *catchable*. With static imports
+        // a missing/mis-served module aborts the whole script silently, leaving
+        // window.Dezaemon undefined with no clue why — the UI then had to guess
+        // at a cause. Record the real error instead and let the UI report it.
+        const BASE = "./tools/dezaemon-import/lib/";
+        try {
+            const [bupSource, bupParse, payloadTable, decodeMod, mapToGame, atlasPack, schema] =
+                await Promise.all([
+                    import(BASE + "bup-source.js"),
+                    import(BASE + "bup-parse.js"),
+                    import(BASE + "payload-table.js"),
+                    import(BASE + "decode/index.js"),
+                    import(BASE + "map-to-game.js"),
+                    import(BASE + "atlas-pack.js"),
+                    import(BASE + "game-schema.js"),
+                ]);
+            window.Dezaemon = Object.assign({}, bupSource, bupParse, payloadTable, mapToGame, {
+                decodeSave: decodeMod.decodeSave,
+                packShelf: atlasPack.packShelf,
+                validateGameJson: schema.validateGameJson,
+            });
+        } catch (err) {
+            window.DezaemonLoadError = err;
+            console.error("Dezaemon module failed to load:", err);
+        }
         window.dispatchEvent(new Event("dezaemon-ready"));
     </script>
     <style>
@@ -2528,13 +2545,37 @@
             document.getElementById('status').innerHTML = '<span style="color:#84cc16">New game (unsaved)</span>';
         }
 
+        // Explain an unavailable window.Dezaemon using the error the module
+        // loader actually recorded, rather than assuming a cause. The failure
+        // modes look identical from the UI but need different fixes.
+        function dezaemonUnavailableMessage() {
+            const err = window.DezaemonLoadError;
+            const why = err ? (err.message || String(err)) : 'the module script never ran';
+            let hint;
+            if (location.protocol === 'file:') {
+                hint = 'The editor is open over file:// — browsers block ES module imports there. '
+                    + 'Serve the folder over http instead (e.g. `npx vite` from the repo root, or '
+                    + '`node tests/e2e/static-server.js 3210`) and open it via http://localhost/…';
+            } else if (/failed to fetch|networkerror|importing a module script failed|error loading dynamically imported module|404/i.test(why)) {
+                hint = 'tools/dezaemon-import/lib/*.js could not be fetched from ' + location.origin + '. '
+                    + 'If this is a deployed copy of the editor, that folder most likely was not uploaded '
+                    + 'alongside level-editor.html — the importer modules must ship with it.';
+            } else if (/mime|expected a javascript/i.test(why)) {
+                hint = 'The server sent the module with a non-JavaScript MIME type. '
+                    + 'Configure it to serve .js as text/javascript.';
+            } else {
+                hint = 'See the browser console for the failing import.';
+            }
+            return 'Dezaemon module failed to load.\n\n' + why + '\n\n' + hint;
+        }
+
         function openDezaemonImport() {
-            if (!window.Dezaemon) { alert('Dezaemon module failed to load (serve the editor over http, not file://)'); return; }
+            if (!window.Dezaemon) { alert(dezaemonUnavailableMessage()); return; }
             document.getElementById('deza-file-input').click();
         }
 
         async function handleDezaemonFile(file) {
-            if (!window.Dezaemon) { alert('Dezaemon module failed to load'); return; }
+            if (!window.Dezaemon) { alert(dezaemonUnavailableMessage()); return; }
             let saves, kind;
             try {
                 const u8 = new Uint8Array(await file.arrayBuffer());

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "node --test tools/dezaemon-import/test/",
+    "test:unit": "node --test \"tools/dezaemon-import/test/**/*.test.js\"",
     "test:e2e": "npm --prefix tests/e2e run test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "node --test \"tools/dezaemon-import/test/**/*.test.js\"",
+    "test:unit": "npm --prefix tools/dezaemon-import run test",
     "test:e2e": "npm --prefix tests/e2e run test"
   },
   "devDependencies": {

--- a/tests/e2e/specs/dezaemon-module-failure.spec.js
+++ b/tests/e2e/specs/dezaemon-module-failure.spec.js
@@ -1,0 +1,59 @@
+"use strict";
+// The importer modules are fetched at runtime from tools/dezaemon-import/lib/.
+// When that fetch fails (most often: a deployed copy of level-editor.html
+// shipped without the tools/ folder) the editor used to fail silently and then
+// blame file:// serving, which sent people looking in the wrong place. These
+// specs pin the diagnostic to the error that actually occurred.
+const { test, expect } = require("@playwright/test");
+const { blockCdn } = require("../helpers/hermetic");
+
+// Serve level-editor.html normally but 404 the importer modules.
+async function breakImporterModules(page) {
+    await page.route("**/tools/dezaemon-import/**", (route) =>
+        route.fulfill({ status: 404, contentType: "text/plain", body: "not found" })
+    );
+}
+
+test("records why the importer module failed instead of failing silently", async ({ page }) => {
+    await blockCdn(page);
+    await breakImporterModules(page);
+
+    await page.goto("/level-editor.html");
+    // The loader still finishes and announces itself, but reports the failure.
+    await expect.poll(() => page.evaluate(() => "DezaemonLoadError" in window)).toBe(true);
+    expect(await page.evaluate(() => !!window.Dezaemon)).toBe(false);
+    expect(await page.evaluate(() => String(window.DezaemonLoadError))).toBeTruthy();
+});
+
+test("blames the missing modules, not file://, when the editor is served over http", async ({ page }) => {
+    await blockCdn(page);
+    await breakImporterModules(page);
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => "DezaemonLoadError" in window)).toBe(true);
+
+    const message = await page.evaluate(() => window.dezaemonUnavailableMessage());
+    expect(message).toContain("Dezaemon module failed to load");
+    expect(message).toContain("tools/dezaemon-import/lib/*.js could not be fetched");
+    // The old message hard-coded this guess; over http it is simply wrong.
+    expect(message).not.toContain("not file://");
+});
+
+test("the import button surfaces that message rather than opening a file picker", async ({ page }) => {
+    await blockCdn(page);
+    await breakImporterModules(page);
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => "DezaemonLoadError" in window)).toBe(true);
+
+    // Accept from the handler: an unhandled alert() blocks the click itself.
+    let alerted = null;
+    page.on("dialog", async (d) => { alerted = d.message(); await d.accept(); });
+
+    let filePickerOpened = false;
+    page.on("filechooser", () => { filePickerOpened = true; });
+
+    await page.evaluate(() => window.openMenu());
+    await page.locator('#menu-panel button:has-text("Import .sav")').click();
+
+    await expect.poll(() => alerted).toContain("could not be fetched");
+    expect(filePickerOpened).toBe(false);
+});


### PR DESCRIPTION
## Problem

Loading a `.sav` in the level editor alerted:

> Dezaemon module failed to load (serve the editor over http, not file://)

That message hard-codes a guess. When the editor is served over **http** — a deployed copy, for instance — the `file://` hint is wrong and points at the wrong fix.

Two things were wrong underneath:

1. **The failure was unrecoverable and silent.** The importer was pulled in with static `import` statements. One missing or mis-served module aborts the entire `<script type="module">`, so `window.Dezaemon` stays `undefined` and the only trace of *why* is a console message nobody sees before hitting the alert.
2. **The guard guessed.** Three genuinely different failures (file:// CORS, modules not reachable, wrong MIME type) look identical from the UI but need different fixes.

Verified locally that the pipeline itself is healthy — served over http, `window.Dezaemon` populates with all 28 exports and the real `ramsie.sav` imports end to end. The bug is purely in how a load failure is detected and reported.

## Change

- Load the seven `tools/dezaemon-import/lib/` modules via **dynamic `import()` inside a `try`/`catch`** so a failure is catchable; record it on `window.DezaemonLoadError`. Same exports, same `dezaemon-ready` event.
- Add `dezaemonUnavailableMessage()`, which reports the actual error text plus a cause-specific hint:
  - `file://` → serve over http (with the concrete commands)
  - unfetchable modules → *"`tools/dezaemon-import/lib/*.js` could not be fetched from `<origin>`"* and a note that the folder must ship alongside `level-editor.html`
  - bad MIME → configure `.js` as `text/javascript`
- Use it in both `window.Dezaemon` guards.

### Drive-by: `npm run test:unit` never ran

`node --test tools/dezaemon-import/test/` resolves the path as a *module* on Node 22 and dies with `MODULE_NOT_FOUND` — so the unit suite silently wasn't executing. A quoted glob discovers it properly.

## Test plan

- [x] New `tests/e2e/specs/dezaemon-module-failure.spec.js` routes `**/tools/dezaemon-import/**` to 404 and asserts the failure is recorded, the message blames the missing modules (and **not** `file://`) when served over http, and the Import .sav button surfaces it instead of opening a file picker.
- [x] e2e: 6/6 pass (3 new + `editor-loads`, `new-game-wizard`, `sav-import` unaffected).
- [x] unit: 42 tests, 41 pass, 1 skipped, 0 fail — previously the script errored without running anything.
- [x] Manually confirmed both branches in Chromium: over http `window.Dezaemon` exposes all 28 exports; over `file://` the message correctly identifies the protocol as the cause.

## Note

I couldn't probe `easierbycode.com` from this sandbox (network policy returns 403 on CONNECT), so I could not confirm which cause applies to the deployment. After this change the alert itself will say — if it reports "could not be fetched", `tools/dezaemon-import/lib/` isn't deployed next to `level-editor.html`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnCqayr25BLHekRXJGLP9v)_