### PR TITLE
Import a Dezaemon .sav directly from a URL

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -492,6 +492,9 @@
             <div class="menu-section-title">Dezaemon 2</div>
             <button class="menu-btn" onclick="startNewGame();closeMenu()">✨ New Game</button>
             <button class="menu-btn" onclick="openDezaemonImport();closeMenu()">🛸 Import .sav</button>
+            <input id="deza-url-input" type="url" placeholder="https://…/game.sav" class="menu-input"
+                   onkeydown="if(event.key==='Enter')document.getElementById('deza-url-btn').click()">
+            <button id="deza-url-btn" class="menu-btn" onclick="importDezaemonFromUrlInput()">🌐 Import .sav from URL</button>
         </div>
         <div class="menu-section">
             <div class="menu-section-title">Game Save (Cloud)</div>
@@ -2575,23 +2578,80 @@
         }
 
         async function handleDezaemonFile(file) {
-            if (!window.Dezaemon) { alert(dezaemonUnavailableMessage()); return; }
+            const u8 = new Uint8Array(await file.arrayBuffer());
+            return ingestDezaemonBytes(u8, file.name);
+        }
+
+        // Shared tail of both import paths (file picker and URL). `label`
+        // identifies the image in the modal header. Returns true on success so
+        // callers can react; all failures are reported to the user here.
+        async function ingestDezaemonBytes(u8, label) {
+            if (!window.Dezaemon) { alert(dezaemonUnavailableMessage()); return false; }
             let saves, kind;
             try {
-                const u8 = new Uint8Array(await file.arrayBuffer());
                 const norm = await window.Dezaemon.normalize(u8);
                 kind = norm.kind;
                 saves = window.Dezaemon.parse(norm.data);
             } catch (e) {
                 alert('Not a Saturn backup image: ' + e.message);
-                return;
+                return false;
             }
-            if (!saves.length) { alert('No save entries found in this image (empty cart?)'); return; }
-            dezaImportState = { containerKind: kind, saves, selectedSlot: null, decoded: null, fileName: file.name };
-            document.getElementById('deza-container-kind').textContent = `${file.name} · ${kind} · ${saves.length} ${saves.length === 1 ? 'entry' : 'entries'}`;
+            if (!saves.length) { alert('No save entries found in this image (empty cart?)'); return false; }
+            dezaImportState = { containerKind: kind, saves, selectedSlot: null, decoded: null, fileName: label };
+            document.getElementById('deza-container-kind').textContent = `${label} · ${kind} · ${saves.length} ${saves.length === 1 ? 'entry' : 'entries'}`;
             document.getElementById('deza-slot-detail').classList.add('hidden');
             renderDezaemonSlots();
             document.getElementById('dezaemon-import-modal').classList.remove('hidden');
+            return true;
+        }
+
+        // Derive a display label from a URL: the last path segment, decoded
+        // (".../Dezaemon%202%20(DAIOH).sav" -> "Dezaemon 2 (DAIOH).sav").
+        function dezaemonLabelFromUrl(url) {
+            try {
+                const p = new URL(url, location.href).pathname;
+                const last = p.split('/').filter(Boolean).pop() || url;
+                return decodeURIComponent(last);
+            } catch { return url; }
+        }
+
+        // Fetch a .sav over http(s) and run it through the same pipeline as the
+        // file picker. Cross-origin reads need CORS on the host serving the
+        // file, so a failure here is usually the remote's headers rather than a
+        // bad URL — say so instead of a bare "Failed to fetch".
+        async function loadDezaemonFromUrl(url) {
+            if (!window.Dezaemon) { alert(dezaemonUnavailableMessage()); return false; }
+            let resp;
+            try {
+                resp = await fetch(url, { mode: 'cors', credentials: 'omit' });
+            } catch (e) {
+                const sameOrigin = (() => {
+                    try { return new URL(url, location.href).origin === location.origin; }
+                    catch { return false; }
+                })();
+                alert('Could not fetch ' + url + '\n\n' + (e.message || e) + '\n\n'
+                    + (sameOrigin
+                        ? 'The request failed before a response arrived — check the path and that the server is reachable.'
+                        : 'This is a cross-origin request, so the server must send an '
+                          + 'Access-Control-Allow-Origin header that permits ' + location.origin + '. '
+                          + 'If you cannot change that host, download the .sav and use "Import .sav" instead.'));
+                return false;
+            }
+            if (!resp.ok) {
+                alert('Could not fetch ' + url + '\n\nHTTP ' + resp.status + ' ' + resp.statusText);
+                return false;
+            }
+            const u8 = new Uint8Array(await resp.arrayBuffer());
+            return ingestDezaemonBytes(u8, dezaemonLabelFromUrl(url));
+        }
+
+        async function importDezaemonFromUrlInput() {
+            const input = document.getElementById('deza-url-input');
+            const url = (input.value || '').trim();
+            if (!url) { alert('Enter the URL of a .sav / .bcr / .bkr file first.'); return false; }
+            const ok = await loadDezaemonFromUrl(url);
+            if (ok) closeMenu();
+            return ok;
         }
 
         function renderDezaemonSlots() {
@@ -5501,6 +5561,13 @@ if (!name) { name = prompt('Level name:'); if (!name) return; }
             await autoLoadFromServer();
             const urlParams = new URLSearchParams(window.location.search);
             if (urlParams.get('new')) { startNewGame(); return; }
+            // ?sav=<url> opens the importer straight from a link.
+            const urlSav = urlParams.get('sav');
+            if (urlSav) {
+                document.getElementById('deza-url-input').value = urlSav;
+                await loadDezaemonFromUrl(urlSav);
+                return;
+            }
             const urlLevel = urlParams.get('level');
             if (urlLevel) {
                 document.getElementById('firebase-level-name').value = urlLevel;

--- a/tests/e2e/specs/dezaemon-module-failure.spec.js
+++ b/tests/e2e/specs/dezaemon-module-failure.spec.js
@@ -52,7 +52,8 @@ test("the import button surfaces that message rather than opening a file picker"
     page.on("filechooser", () => { filePickerOpened = true; });
 
     await page.evaluate(() => window.openMenu());
-    await page.locator('#menu-panel button:has-text("Import .sav")').click();
+    // :text-is — "Import .sav from URL" also contains "Import .sav".
+    await page.locator('#menu-panel button:text-is("🛸 Import .sav")').click();
 
     await expect.poll(() => alerted).toContain("could not be fetched");
     expect(filePickerOpened).toBe(false);

--- a/tests/e2e/specs/sav-import-url.spec.js
+++ b/tests/e2e/specs/sav-import-url.spec.js
@@ -1,0 +1,134 @@
+"use strict";
+// Importing a .sav straight from a URL, rather than through the file picker.
+//
+// Remote hosts are simulated with page.route so these stay hermetic: a real
+// cross-origin fetch would depend on someone else's CORS headers and uptime.
+// The fixture bytes are the same ramsie.sav the file-picker spec uses, so a
+// URL import is expected to land on byte-identical state.
+const fs = require("fs");
+const path = require("path");
+const { test, expect } = require("@playwright/test");
+const { blockCdn, collectPageErrors } = require("../helpers/hermetic");
+
+const RAMSIE = path.resolve(__dirname, "..", "..", "..", "tools", "dezaemon-import", "fixtures", "ramsie.sav");
+const RAMSIE_PATH = "/tools/dezaemon-import/fixtures/ramsie.sav";
+// The shape that prompted this feature: spaces and parens in the filename.
+const REMOTE_URL = "https://easierbycode.com/assets/Dezaemon 2 (DAIOH).sav";
+
+// Serve the fixture for `url` as a properly CORS-enabled remote host would.
+async function serveRemoteSav(page, url) {
+    const body = fs.readFileSync(RAMSIE);
+    await page.route(url, (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: "application/octet-stream",
+            headers: { "access-control-allow-origin": "*" },
+            body,
+        })
+    );
+}
+
+async function openEditor(page) {
+    await blockCdn(page);
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => !!window.Dezaemon)).toBe(true);
+}
+
+test("imports a .sav from a same-origin URL via the menu field", async ({ page }) => {
+    const errors = collectPageErrors(page);
+    page.on("dialog", (d) => d.accept());
+    await openEditor(page);
+
+    await page.evaluate(() => window.openMenu());
+    await page.fill("#deza-url-input", RAMSIE_PATH);
+    await page.click("#deza-url-btn");
+
+    await expect(page.locator("#dezaemon-import-modal")).toBeVisible();
+    await expect(page.locator("#deza-container-kind")).toContainText("ramsie.sav");
+    await expect(page.locator("#deza-container-kind")).toContainText("interleaved");
+
+    // Same golden metadata the file-picker path produces.
+    const slot = page.locator("#deza-slot-list > div").first();
+    await expect(slot).toContainText("DEZA2 SGM");
+    await expect(slot).toContainText("DEZA2____01");
+
+    // And it imports through to the editor.
+    await slot.click();
+    await expect(page.locator("#deza-decoded-summary")).toContainText("167,511 bytes, 331 blocks");
+    await page.locator("#deza-import-btn").click();
+    await expect(page.locator("#dezaemon-import-modal")).toBeHidden();
+    const state = await page.evaluate(() => window.__editorState());
+    expect(state.status).toContain("Imported: DEZA2 SGM");
+
+    expect(errors).toEqual([]);
+});
+
+test("decodes a percent-encoded remote filename for the modal header", async ({ page }) => {
+    await openEditor(page);
+    await serveRemoteSav(page, REMOTE_URL);
+
+    await page.evaluate((u) => window.loadDezaemonFromUrl(u), REMOTE_URL);
+
+    await expect(page.locator("#dezaemon-import-modal")).toBeVisible();
+    // Shown as the human-readable filename, not the escaped path.
+    await expect(page.locator("#deza-container-kind")).toContainText("Dezaemon 2 (DAIOH).sav");
+    await expect(page.locator("#deza-container-kind")).not.toContainText("%20");
+});
+
+test("?sav= loads the importer straight from a link", async ({ page }) => {
+    await blockCdn(page);
+    await serveRemoteSav(page, REMOTE_URL);
+
+    await page.goto("/level-editor.html?sav=" + encodeURIComponent(REMOTE_URL));
+
+    await expect(page.locator("#dezaemon-import-modal")).toBeVisible();
+    await expect(page.locator("#deza-container-kind")).toContainText("Dezaemon 2 (DAIOH).sav");
+    // The field is seeded so the URL is visible and re-runnable.
+    await expect(page.locator("#deza-url-input")).toHaveValue(REMOTE_URL);
+});
+
+test("a blocked cross-origin fetch blames CORS, not the URL", async ({ page }) => {
+    await openEditor(page);
+    // No ACAO header / connection refused — what a non-CORS host looks like.
+    await page.route(REMOTE_URL, (route) => route.abort());
+
+    let alerted = null;
+    page.on("dialog", async (d) => { alerted = d.message(); await d.accept(); });
+    await page.evaluate((u) => window.loadDezaemonFromUrl(u), REMOTE_URL);
+
+    await expect.poll(() => alerted).toContain("Access-Control-Allow-Origin");
+    expect(alerted).toContain("Import .sav");            // the offered fallback
+    expect(await page.locator("#dezaemon-import-modal").isVisible()).toBe(false);
+});
+
+test("reports the status code when the remote returns an error", async ({ page }) => {
+    await openEditor(page);
+    await page.route(REMOTE_URL, (route) =>
+        route.fulfill({ status: 404, headers: { "access-control-allow-origin": "*" }, body: "nope" })
+    );
+
+    let alerted = null;
+    page.on("dialog", async (d) => { alerted = d.message(); await d.accept(); });
+    await page.evaluate((u) => window.loadDezaemonFromUrl(u), REMOTE_URL);
+
+    await expect.poll(() => alerted).toContain("HTTP 404");
+    expect(await page.locator("#dezaemon-import-modal").isVisible()).toBe(false);
+});
+
+test("rejects a URL that is not a Saturn backup image", async ({ page }) => {
+    await openEditor(page);
+    await page.route(REMOTE_URL, (route) =>
+        route.fulfill({
+            status: 200,
+            headers: { "access-control-allow-origin": "*" },
+            body: Buffer.alloc(4096), // right size, no BUP magic
+        })
+    );
+
+    let alerted = null;
+    page.on("dialog", async (d) => { alerted = d.message(); await d.accept(); });
+    await page.evaluate((u) => window.loadDezaemonFromUrl(u), REMOTE_URL);
+
+    await expect.poll(() => alerted).toContain("Not a Saturn backup image");
+    expect(await page.locator("#dezaemon-import-modal").isVisible()).toBe(false);
+});


### PR DESCRIPTION
## What

Load a Dezaemon 2 `.sav` straight from a URL instead of downloading it first. Two entry points:

- A **URL field** in the menu's Dezaemon 2 section, next to `🛸 Import .sav`.
- **`?sav=<url>`** — opens the importer directly from a link, e.g.
  `level-editor.html?sav=https%3A%2F%2Feasierbycode.com%2Fassets%2FDezaemon%25202%2520(DAIOH).sav`

Both funnel into `ingestDezaemonBytes()` — the existing file-picker tail factored out — so a URL import lands on byte-identical state rather than a second implementation drifting from the first.

## Error reporting

A failed `fetch()` surfaces as a bare `TypeError: Failed to fetch`, which tells you nothing actionable. Cross-origin reads need `Access-Control-Allow-Origin` from whatever host serves the `.sav`, and that's not something the URL can express — so that case says so explicitly and offers the download-and-use-`Import .sav` fallback. HTTP errors report their status; non-Saturn payloads keep the existing "Not a Saturn backup image" message.

The modal header shows the decoded filename (`Dezaemon 2 (DAIOH).sav`, not the `%20`-escaped path) since these URLs tend to carry spaces and parens.

## Test plan

New `tests/e2e/specs/sav-import-url.spec.js` — remote hosts are simulated with `page.route` so the specs stay hermetic (a real cross-origin fetch would depend on a third party's CORS headers and uptime). Fixture bytes are the same `ramsie.sav` the file-picker spec uses:

- [x] Same-origin URL through the menu field → modal shows `ramsie.sav · interleaved`, same golden slot metadata (`DEZA2 SGM`, `167,511 bytes, 331 blocks`), imports through to `Imported: DEZA2 SGM`
- [x] Percent-encoded remote filename renders decoded, with no `%20`
- [x] `?sav=` opens the importer on load and seeds the field
- [x] Blocked cross-origin fetch → message names `Access-Control-Allow-Origin`, offers the fallback, modal stays closed
- [x] `404` → message reports `HTTP 404`
- [x] Non-BUP payload → `Not a Saturn backup image`

Full suite: **12/12 e2e pass**, unit **41 pass / 1 skipped**. One pre-existing selector in `dezaemon-module-failure.spec.js` needed `:text-is` since the new button also contains the substring "Import .sav".

## Note

I couldn't verify the real `easierbycode.com` URL end to end — this sandbox's network policy 403s outbound CONNECT. Whether that specific host works depends on it sending `Access-Control-Allow-Origin`; if it doesn't, the new message will say exactly that and point at the file-picker fallback.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnCqayr25BLHekRXJGLP9v)_