### PR TITLE
Ship importer modules to Pages; say when an import decoded to an empty skeleton

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -344,6 +344,28 @@ jobs:
           cp manifest.json dist/ || true
           cp favicon.ico dist/ || true
           cp app-original.js dist/ || true
+          # level-editor.html imports the Dezaemon importer as ES modules at
+          # runtime, so lib/ has to ship with it. Only lib/ — it is
+          # self-contained (relative imports only), and the rest of
+          # tools/dezaemon-import is CLI/test/fixture weight, including
+          # multi-MB .sav files.
+          mkdir -p dist/tools/dezaemon-import
+          cp -r tools/dezaemon-import/lib dist/tools/dezaemon-import/
+
+      - name: Verify the editor's runtime modules shipped
+        run: |
+          # Guards the failure this check was added for: level-editor.html
+          # deployed without tools/dezaemon-import/lib, so every import 404s
+          # and the .sav importer is dead on the live site.
+          missing=0
+          for f in $(find tools/dezaemon-import/lib -name '*.js' | sort); do
+            if [ ! -f "dist/$f" ]; then
+              echo "::error::$f is imported by level-editor.html but missing from dist/"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then exit 1; fi
+          echo "OK: $(find dist/tools/dezaemon-import/lib -name '*.js' | wc -l) importer modules present in dist/"
 
       - name: Download APK artifact
         uses: actions/download-artifact@v4

--- a/tests/e2e/specs/sav-import.spec.js
+++ b/tests/e2e/specs/sav-import.spec.js
@@ -9,7 +9,8 @@ test("importing a real Dezaemon 2 .sav populates the modal and the editor", asyn
     await blockCdn(page);
     const errors = collectPageErrors(page);
     // applyDezaemonImport() reports import notes via alert() — auto-accept.
-    page.on("dialog", (d) => d.accept());
+    const notes = [];
+    page.on("dialog", (d) => { notes.push(d.message()); d.accept(); });
 
     await page.goto("/level-editor.html");
     await expect.poll(() => page.evaluate(() => !!window.Dezaemon)).toBe(true);
@@ -44,6 +45,17 @@ test("importing a real Dezaemon 2 .sav populates the modal and the editor", asyn
     expect(meta.source).toBe("dezaemon2");
     expect(meta.sourceComment).toBe("DEZA2 SGM");
     expect(meta.sourceFilename).toBe("DEZA2____01");
+
+    // The section decoders are still open work, so this import is a skeleton:
+    // it must say so rather than look like a success that plays as a black
+    // screen. Assert the user was actually told, not just the CLI.
+    const importNotes = notes.join("\n");
+    expect(importNotes).toContain("nothing will spawn");
+    expect(importNotes).toContain("none of its content yet");
+
+    // ...which is exactly what the emitted stage contains.
+    const waves = await page.evaluate(() => gameData.stage0.enemylist);
+    expect(waves.every((row) => row.every((cell) => cell === "00"))).toBe(true);
 
     expect(errors).toEqual([]);
 });

--- a/tools/dezaemon-import/lib/map-to-game.js
+++ b/tools/dezaemon-import/lib/map-to-game.js
@@ -199,5 +199,29 @@ export function mapSaveToGame(decoded, { defaults = BUILTIN_DEFAULTS, sourceEntr
     gameJson.continueComment = "";
     gameJson.continueCommentEn = "";
 
+    // A save can parse perfectly — container, block chain, section table,
+    // decompression — and still yield no game content, because the *meaning*
+    // of the decompressed sections is still being reverse-engineered
+    // (FORMAT.md, "Open: decoded section semantics"). Falling back to engine
+    // defaults without saying so looks like a successful import right up until
+    // you press play and get an empty stage, so name each gap.
+    if (!sprites.length) {
+        warnings.push("no CG/sprite data decoded from this save — using the default art");
+    }
+    if (!decodedEnemies.length) {
+        warnings.push("no enemy table decoded from this save — using the default starter enemy");
+    }
+    if (!decodedStages.length) {
+        warnings.push(
+            "no stage layout decoded from this save — every wave is empty, so nothing will spawn"
+        );
+    }
+    if (!sprites.length && !decodedEnemies.length && !decodedStages.length) {
+        warnings.push(
+            "this import carries the save's identity but none of its content yet; " +
+            "decoding the section contents is still open work (see FORMAT.md)"
+        );
+    }
+
     return { gameJson, sprites, warnings };
 }

--- a/tools/dezaemon-import/test/map-to-game.test.js
+++ b/tools/dezaemon-import/test/map-to-game.test.js
@@ -44,10 +44,26 @@ test("mapSaveToGame on an undecoded save yields a valid skeleton", () => {
     assert.deepStrictEqual(errors, []);
     assert.ok(ok);
     assert.strictEqual(sprites.length, 0);
-    assert.deepStrictEqual(warnings, []);
     assert.strictEqual(gameJson.meta.source, "dezaemon2");
     assert.strictEqual(gameJson.meta.sourceComment, "DEZA2 SGM");
     assert.strictEqual(gameJson.meta.sourceFilename, "DEZA2____01");
+    // The skeleton is valid and playable, but it is empty — that has to be
+    // said, or the import reads as a success until you press play.
+    assert.ok(warnings.some((w) => w.includes("no CG/sprite data decoded")));
+    assert.ok(warnings.some((w) => w.includes("no enemy table decoded")));
+    assert.ok(warnings.some((w) => w.includes("nothing will spawn")));
+    assert.ok(warnings.some((w) => w.includes("none of its content yet")));
+});
+
+test("a partial decode only warns about the parts that are still missing", () => {
+    const decoded = emptyDecoded();
+    decoded.enemies = [{ name: "zako", hp: 2 }];
+    const { warnings } = mapSaveToGame(decoded);
+    assert.ok(!warnings.some((w) => w.includes("no enemy table decoded")));
+    assert.ok(warnings.some((w) => w.includes("no CG/sprite data decoded")));
+    assert.ok(warnings.some((w) => w.includes("nothing will spawn")));
+    // The catch-all only fires when nothing at all came through.
+    assert.ok(!warnings.some((w) => w.includes("none of its content yet")));
 });
 
 test("mapSaveToGame is deterministic", () => {


### PR DESCRIPTION
Two fixes from one report: the deployed editor couldn't load the importer, and once it could, importing a real save played as a black screen with no explanation.

## 1. The importer modules never shipped to Pages

`level-editor.html` imports `tools/dezaemon-import/lib/*.js` as ES modules at runtime, but the Pages build copied only `assets`, `src`, `lib`, `icons` and a list of HTML files. The deployed editor 404'd every import:

```
error loading dynamically imported module:
https://easierbycode.com/2019-es7/tools/dezaemon-import/lib/bup-source.js
```

Copy `lib/` into `dist`. **Only** `lib/` — it imports nothing but its own relative siblings, so it's self-contained, while the rest of `tools/dezaemon-import` is CLI, tests, and multi-MB `.sav` fixtures no browser needs.

Also added a **verification step**: every `.js` under `tools/dezaemon-import/lib` must exist in `dist/` or the deploy fails. Nothing caught this before because the modules are fetched at runtime — the build happily produced a `dist` that only broke when a user clicked Import.

## 2. A successful-looking import that plays as a black screen

Importing a real `.sav` reported `Imported: DEZA2 SGM`, then nothing spawned. That's the importer working as currently built — container, block chain, section table, and LZSS decompression all succeed, but the *meaning* of the decompressed sections is still open work (FORMAT.md, "Open: decoded section semantics"). Confirmed against the fixture:

```
$ node tools/dezaemon-import/index.js …/ramsie.sav --out …
  sprites: 0, enemies: 1, stages: 1
```

…where the 1 enemy is the engine default and all 8 waves are `"00"`.

`mapSaveToGame` silently substituted defaults and returned **no warnings**, so the editor showed no import notes at all. The CLI did warn, but that check lived in `index.js` rather than the shared mapper, so the editor never inherited it. Warning from the mapper fixes both surfaces from one place, and the warnings narrow on their own as decoders land:

> no CG/sprite data decoded from this save — using the default art
> no enemy table decoded from this save — using the default starter enemy
> no stage layout decoded from this save — every wave is empty, so nothing will spawn
> this import carries the save's identity but none of its content yet

The skeleton is still valid and playable — it just isn't the user's game yet, and the import should say so.

## Test plan

- [x] Simulated the Pages `dist` assembly locally; the verification step reports `OK: 10 importer modules present in dist/`, and fails when the copy is removed.
- [x] Unit: **43 pass, 0 fail**. Updated the skeleton test (it previously asserted *no* warnings — the exact behavior being fixed) and added a partial-decode test proving warnings narrow to what's genuinely missing and the catch-all only fires when nothing decodes.
- [x] e2e: **12/12 pass**. `sav-import.spec.js` now asserts the user is actually shown the warning, and that `stage0` really is all-empty — tying the message to the observable symptom.

## Not fixed here

This doesn't make the DAIOH game *playable* — decoding the section contents into sprites, enemies and stage scripts is the remaining reverse-engineering work, and per FORMAT.md it needs controlled-delta save captures to localize the fields. This PR makes the current state honest rather than silently empty.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnCqayr25BLHekRXJGLP9v)_