### PR TITLE
Fly the Evil Invaders ship in imported Dezaemon games

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -1258,6 +1258,17 @@
                 if (b.anim) { for (const [k, animFrames] of Object.entries(b.anim)) { if (!k.startsWith('_')) collectTextures(animFrames); } }
                 if (b.bulletData) collectTextures(b.bulletData.texture);
             }
+            // The player was long assumed to be stock art, so it went unchecked —
+            // but a level (or an import) can point it at frames that are not in
+            // the atlas, and an invisible ship firing invisible shots is exactly
+            // the failure this panel exists to catch.
+            if (playerData) {
+                collectTextures(playerData.texture);
+                for (const shoot of ['shootNormal', 'shootBig', 'shoot3way']) {
+                    if (playerData[shoot]) collectTextures(playerData[shoot].texture);
+                }
+                if (playerData.barrier) collectTextures(playerData.barrier.texture);
+            }
 
             if (missing.size > 0) {
                 console.warn('Level editor: missing textures in atlas:', [...missing]);
@@ -2537,6 +2548,11 @@
             } catch (e) { /* leave null — BUILTIN_DEFAULTS covers it */ }
         }
 
+        // Records a new game / an import is seeded from: the currently loaded
+        // game where it has one, the module's built-ins otherwise. Note that a
+        // .sav import ignores `playerData` here and always uses the Evil
+        // Invaders character (see applyDezaemonImport) — this override only
+        // reaches "New Game", which keeps editing the player you already have.
         function getDezaemonDefaults() {
             const base = window.Dezaemon ? dezaClone(window.Dezaemon.BUILTIN_DEFAULTS) : null;
             if (!base) return null;
@@ -2787,6 +2803,9 @@
             if (!st || st.selectedSlot === null || !st.decoded) return;
             const save = st.saves[st.selectedSlot];
             snapshotDefaultsOnce();
+            // mapSaveToGame supplies the Evil Invaders player and its bullets
+            // regardless of `defaults` — a Dezaemon save has no player of its
+            // own, and the atlas reset below would strip a custom one's frames.
             const { gameJson, sprites, warnings } = window.Dezaemon.mapSaveToGame(st.decoded, {
                 defaults: getDezaemonDefaults(),
                 sourceEntry: save,
@@ -2836,6 +2855,8 @@
             document.getElementById('status').innerHTML = '<span style="color:#84cc16">Imported: ' + title + ' (Dezaemon 2)</span>';
             document.getElementById('dezaemon-import-modal').classList.add('hidden');
             const notes = warnings.slice();
+            notes.push('Player and bullets: the Evil Invaders character (' +
+                playerData.texture.length + ' idle frames + shot/big/3way), since Dezaemon saves carry no player.');
             if (sprites.length) notes.push(sprites.length + ' sprites from the save were packed into the atlas.');
             if (notes.length) alert('Import notes:\n- ' + notes.join('\n- '));
         }

--- a/tests/e2e/specs/sav-import.spec.js
+++ b/tests/e2e/specs/sav-import.spec.js
@@ -77,10 +77,91 @@ test("importing a real Dezaemon 2 .sav populates the modal and the editor", asyn
     expect(grid.withSprite).toBe(grid.occupied);
     expect(grid.distinct).toBeGreaterThan(1);
 
+    // A Dezaemon save has no player of its own, so the import flies the Evil
+    // Invaders character — and every frame it references, ship and bullets
+    // alike, has to resolve in the atlas the editor just rebuilt around the
+    // save's sprites. Frames that only live in some other level's atlas would
+    // read as a successful import until you press play and see nothing.
+    const player = await page.evaluate(() => {
+        const frames = Object.assign({}, (atlasData && atlasData.frames) || {});
+        for (const s of extraSprites) frames[s.key] = true;
+        for (const k in replacedFrames) frames[k] = true;
+        const pd = gameData.playerData;
+        const referenced = [
+            ...pd.texture,
+            ...pd.shootNormal.texture,
+            ...pd.shootBig.texture,
+            ...pd.shoot3way.texture,
+            ...pd.barrier.texture,
+        ];
+        return {
+            texture: pd.texture,
+            shootNormal: pd.shootNormal.texture,
+            shootBig: pd.shootBig.texture,
+            missing: referenced.filter((f) => !frames[f]),
+        };
+    });
+    expect(player.texture).toEqual([
+        "player00.gif", "player01.gif", "player02.gif",
+        "player03.gif", "player04.gif", "player05.gif",
+    ]);
+    expect(player.shootNormal).toEqual(["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"]);
+    expect(player.shootBig).toEqual(["shotBig00.gif", "shotBig01.gif", "shotBig02.gif", "shotBig03.gif"]);
+    expect(player.missing).toEqual([]);
+
     // Importing must not push files at the user.
     const importNotes = notes.join("\n");
     expect(importNotes).not.toContain("Repack Atlas");
     expect(importNotes).toContain("sprites from the save were packed into the atlas");
+    expect(importNotes).toContain("Player and bullets: the Evil Invaders character");
+
+    expect(errors).toEqual([]);
+});
+
+test("importing over a level with a custom player still flies the Evil Invaders ship", async ({ page }) => {
+    await blockCdn(page);
+    const errors = collectPageErrors(page);
+    page.on("dialog", (d) => d.accept());
+
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => !!window.Dezaemon)).toBe(true);
+    await expect.poll(() => page.evaluate(() => !!(atlasData && atlasData.frames))).toBe(true);
+
+    // Stand in for a loaded Firebase level whose player is custom art: the
+    // frames live in that level's atlas, not the stock one, and the import
+    // clears them to make room for the save's sprites.
+    await page.evaluate(() => {
+        playerData = {
+            name: "borrowed",
+            maxHp: 5,
+            spDamage: 10,
+            defaultShootName: "normal",
+            defaultShootSpeed: "speed_normal",
+            texture: ["levelOnlyShip0.gif"],
+            shootNormal: { name: "normal", damage: 1, hp: 1, interval: 9, texture: ["levelOnlyShot0.gif"] },
+            shootBig: { name: "big", damage: 2, hp: 1, interval: 9, texture: ["levelOnlyShot0.gif"] },
+            shoot3way: { name: "3way", damage: 1, hp: 1, interval: 9, texture: ["levelOnlyShot0.gif"] },
+            barrier: { time: 2, texture: ["levelOnlyBarrier0.gif"] },
+        };
+        gameData.playerData = playerData;
+    });
+
+    await page.setInputFiles("#deza-file-input", RAMSIE);
+    await page.locator("#deza-slot-list > div").first().click();
+    await page.locator("#deza-import-btn").click();
+    await expect(page.locator("#dezaemon-import-modal")).toBeHidden();
+
+    const after = await page.evaluate(() => ({
+        texture: gameData.playerData.texture,
+        shootNormal: gameData.playerData.shootNormal.texture,
+        // The panel that flags unresolvable frames must stay shut — the whole
+        // point is that nothing the player references went missing.
+        missingPanelHidden: document.getElementById("missing-tex-overlay").classList.contains("hidden"),
+    }));
+    expect(after.texture[0]).toBe("player00.gif");
+    expect(after.texture).not.toContain("levelOnlyShip0.gif");
+    expect(after.shootNormal).toEqual(["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"]);
+    expect(after.missingPanelHidden).toBe(true);
 
     expect(errors).toEqual([]);
 });

--- a/tools/dezaemon-import/lib/map-to-game.js
+++ b/tools/dezaemon-import/lib/map-to-game.js
@@ -18,33 +18,44 @@ export const MAX_STAGES = 5;
 export const MAX_ENEMIES = 26;
 export const BLANK_WAVES = 8;
 
+// The Evil Invaders player character, exactly as the Phaser 4 runtime draws
+// it: player00..player05 are the idle animation Player.js builds, shot*/shotBig*
+// are the bullet frames Bullet.js fires for each shoot mode, and barrier0..3 is
+// the shield. Every one of these frames ships in assets/game_asset — the atlas
+// BootScene loads — so a game seeded with this record plays with no extra art.
+//
+// Kept as its own export because a Dezaemon 2 save carries no player: the
+// format's own ship art and stats live in sections we do not decode, so an
+// import has to supply one, and this is the character it supplies.
+export const EVIL_INVADERS_PLAYER = {
+    name: "G",
+    maxHp: 3,
+    spDamage: 50,
+    defaultShootName: "normal",
+    defaultShootSpeed: "speed_normal",
+    texture: ["player00.gif", "player01.gif", "player02.gif", "player03.gif", "player04.gif", "player05.gif"],
+    shootNormal: {
+        name: "normal", damage: 1, hp: 1, interval: 23,
+        texture: ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"],
+    },
+    shootBig: {
+        name: "big", damage: 2, hp: 100, interval: 39,
+        texture: ["shotBig00.gif", "shotBig01.gif", "shotBig02.gif", "shotBig03.gif"],
+    },
+    shoot3way: {
+        name: "3way", damage: 1, hp: 1, interval: 31,
+        texture: ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"],
+    },
+    barrier: {
+        time: 4,
+        texture: ["barrier0.gif", "barrier1.gif", "barrier2.gif", "barrier3.gif"],
+    },
+};
+
 // Default records copied from the shipped assets/game.json — every texture
 // here exists in the stock game_asset atlas.
 export const BUILTIN_DEFAULTS = {
-    playerData: {
-        name: "G",
-        maxHp: 3,
-        spDamage: 50,
-        defaultShootName: "normal",
-        defaultShootSpeed: "speed_normal",
-        texture: ["player00.gif", "player01.gif", "player02.gif", "player03.gif", "player04.gif", "player05.gif"],
-        shootNormal: {
-            name: "normal", damage: 1, hp: 1, interval: 23,
-            texture: ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"],
-        },
-        shootBig: {
-            name: "big", damage: 2, hp: 100, interval: 39,
-            texture: ["shotBig00.gif", "shotBig01.gif", "shotBig02.gif", "shotBig03.gif"],
-        },
-        shoot3way: {
-            name: "3way", damage: 1, hp: 1, interval: 31,
-            texture: ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"],
-        },
-        barrier: {
-            time: 4,
-            texture: ["barrier0.gif", "barrier1.gif", "barrier2.gif", "barrier3.gif"],
-        },
-    },
+    playerData: EVIL_INVADERS_PLAYER,
     starterEnemy: {
         name: "soliderA",
         score: 100,
@@ -109,6 +120,10 @@ const NUMERIC_ENEMY_FIELDS = ["score", "spgage", "hp", "speed", "interval", "sha
 // Map a decodeSave() result onto the editor's game.json shape.
 // Returns { gameJson, sprites, warnings }; sprites is the (key-sanitized)
 // list of {key, w, h, rgba} to add to the atlas.
+//
+// `defaults` supplies the enemy and boss records that decoded data is layered
+// onto (starterEnemy / starterBoss); the player is not taken from it — see the
+// EVIL_INVADERS_PLAYER assignment below.
 export function mapSaveToGame(decoded, { defaults = BUILTIN_DEFAULTS, sourceEntry = null, importedAt = null } = {}) {
     const warnings = [];
     const usedKeys = new Set();
@@ -201,7 +216,14 @@ export function mapSaveToGame(decoded, { defaults = BUILTIN_DEFAULTS, sourceEntr
     const bossData = {};
     for (let s = 0; s < stageCount; s++) bossData[`boss${s}`] = clone(defaults.starterBoss);
 
-    gameJson.playerData = clone(defaults.playerData);
+    // Player + bullets always come from the Evil Invaders character, never from
+    // `defaults`. The editor derives `defaults` from whatever game is currently
+    // open, and its player may be a custom one whose frames live only in that
+    // level's atlas — which the import drops when it resets the atlas to make
+    // room for the save's sprites. Seeding from it would leave the imported
+    // game pointing at frames that no longer exist: an invisible ship firing
+    // invisible shots. The stock character's frames are always in game_asset.
+    gameJson.playerData = clone(EVIL_INVADERS_PLAYER);
     gameJson.enemyData = enemyData;
     gameJson.bossData = bossData;
     gameJson.meta = { version: "1.0", source: "dezaemon2" };

--- a/tools/dezaemon-import/test/map-to-game.test.js
+++ b/tools/dezaemon-import/test/map-to-game.test.js
@@ -5,6 +5,7 @@ import {
     mapSaveToGame,
     emptyWave,
     BUILTIN_DEFAULTS,
+    EVIL_INVADERS_PLAYER,
     GRID_COLS,
     MAX_ENEMIES,
     MAX_STAGES,
@@ -135,6 +136,55 @@ test("sprite keys are sanitized, .gif-suffixed, and deduped", () => {
         sprites.map((s) => s.key),
         ["ship_a.gif", "ship_a_2.gif", "deza_cg2.gif"]
     );
+});
+
+test("an import always flies the Evil Invaders character, whatever the defaults say", () => {
+    // The editor derives `defaults` from the game that happens to be open, and
+    // its player can reference frames that live only in that level's atlas —
+    // which the import drops. Taking the player from there would ship an
+    // invisible ship firing invisible bullets, so it comes from the built-in
+    // character instead.
+    const customPlayer = {
+        name: "borrowed",
+        maxHp: 9,
+        spDamage: 1,
+        defaultShootName: "normal",
+        defaultShootSpeed: "speed_normal",
+        texture: ["someLevelOnlyShip0.gif"],
+        shootNormal: { name: "normal", damage: 1, hp: 1, interval: 5, texture: ["someLevelOnlyShot0.gif"] },
+        shootBig: { name: "big", damage: 1, hp: 1, interval: 5, texture: ["someLevelOnlyShot0.gif"] },
+        shoot3way: { name: "3way", damage: 1, hp: 1, interval: 5, texture: ["someLevelOnlyShot0.gif"] },
+        barrier: { time: 1, texture: ["someLevelOnlyBarrier0.gif"] },
+    };
+    const defaults = { ...BUILTIN_DEFAULTS, playerData: customPlayer };
+    const { gameJson } = mapSaveToGame(emptyDecoded(), { defaults });
+
+    assert.deepStrictEqual(gameJson.playerData, EVIL_INVADERS_PLAYER);
+    assert.deepStrictEqual(gameJson.playerData.texture, [
+        "player00.gif", "player01.gif", "player02.gif",
+        "player03.gif", "player04.gif", "player05.gif",
+    ]);
+    assert.deepStrictEqual(gameJson.playerData.shootNormal.texture,
+        ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"]);
+    assert.deepStrictEqual(gameJson.playerData.shootBig.texture,
+        ["shotBig00.gif", "shotBig01.gif", "shotBig02.gif", "shotBig03.gif"]);
+    assert.deepStrictEqual(gameJson.playerData.shoot3way.texture,
+        ["shot00.gif", "shot01.gif", "shot02.gif", "shot03.gif"]);
+    assert.deepStrictEqual(gameJson.playerData.barrier.texture,
+        ["barrier0.gif", "barrier1.gif", "barrier2.gif", "barrier3.gif"]);
+    // ...and it is a copy, so editing the imported game cannot mutate the
+    // character every later import is seeded from.
+    gameJson.playerData.texture.push("mutated.gif");
+    assert.strictEqual(EVIL_INVADERS_PLAYER.texture.length, 6);
+    // The enemy/boss halves of `defaults` are still honoured.
+    assert.strictEqual(gameJson.enemyData.enemyA.name, BUILTIN_DEFAULTS.starterEnemy.name);
+});
+
+test("the Evil Invaders player matches what the Phaser runtime ships", () => {
+    // src/phaser/game-objects/Player.js and Bullet.js hardcode these same keys
+    // as their fallbacks, and every one is a frame in assets/game_asset.
+    assert.strictEqual(BUILTIN_DEFAULTS.playerData, EVIL_INVADERS_PLAYER);
+    assert.deepStrictEqual(buildBlankGame().playerData, EVIL_INVADERS_PLAYER);
 });
 
 test("enemies with decoded sprites get their texture repointed by sprite index", () => {


### PR DESCRIPTION
A Dezaemon 2 save carries no player — the format's own ship art and stats live in sections we don't decode — so `mapSaveToGame` has to supply one. It was taking it from `defaults`, which the editor derives from whatever game happens to be open (`getDezaemonDefaults` → `defaultGameSnapshot`).

Import a `.sav` while a Firebase level with a custom player is loaded and you got that level's player record — while the atlas reset a few lines later (`replacedFrames = {}; extraSprites = []`), which makes room for the save's sprites, dropped the frames that record points at. The result was an invisible ship firing invisible bullets, and nothing said so: `checkMissingTextures()` walked `enemyData` and `bossData` but never `playerData`.

## Changes

**`tools/dezaemon-import/lib/map-to-game.js`**
- Split the player out of `BUILTIN_DEFAULTS` into a named `EVIL_INVADERS_PLAYER` export: `player00.gif`–`player05.gif` for the idle animation, `shot00`–`shot03` / `shotBig00`–`shotBig03` for the shoot modes, `barrier0`–`barrier3` for the shield. These are the same keys `src/phaser/game-objects/Player.js` and `Bullet.js` hardcode as their fallbacks, and every one ships in `assets/game_asset` — the atlas BootScene loads.
- `mapSaveToGame` now always clones that record into `gameJson.playerData`, ignoring `defaults.playerData`. `defaults` still supplies `starterEnemy` / `starterBoss`, and `buildBlankGame` ("New Game") is unchanged — it still keeps the player you already have.

**`level-editor.html`**
- `checkMissingTextures()` now collects `playerData.texture`, all three shoot modes and the barrier, so an unresolvable player surfaces in the missing-textures panel instead of silently.
- The import notes name the substitution, since it is a deliberate one.

## Testing

- `npm run test:unit` — 69 pass, 1 pre-existing skip (`pngjs not installed`). Two new cases: an import ignores a custom `defaults.playerData` and returns the Evil Invaders record (a copy, so editing the imported game can't mutate the source), and the record stays identical to what the Phaser runtime ships.
- `npm run test:e2e` (editor project) — 13 pass. The existing `sav-import` spec now asserts every frame the imported player references resolves in the rebuilt atlas; a new spec imports over a level with a custom player and checks the ship comes back stock with the missing-textures panel shut. That new spec fails on `main`'s behaviour (`Expected: "player00.gif" / Received: "levelOnlyShip0.gif"`), confirming it covers the fix.
- Booted the imported Ramsie save through `phaser-game.html?editorPlay=1`: the ship draws `player01.gif` from a real atlas frame and fires `shot00.gif`.

## Note, out of scope

Imported *enemy* art still doesn't reach the Phaser runtime — the editor's Play handoff sends a recipe but no atlas, so `deza*.gif` frames exist only in the editor and the runtime logs `Texture "game_asset" has no frame "deza02_1.gif"`. That predates this change and is untouched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6VnhBanTk5av2cFkpydHN)_