### PR TITLE
Send the editor's atlas to the game when you press Play

### DIFF
--- a/level-editor.html
+++ b/level-editor.html
@@ -811,10 +811,13 @@
             }
             if (!atlasData || !atlasData.frames) return Promise.resolve(false);
             if (!(atlasImage && atlasImage.complete && atlasImage.naturalWidth > 0)) return Promise.resolve(false);
-            // Snapshot the key with the frames: the editor can be pointed at
-            // game_ui, and dropping that atlas onto the runtime's game_asset
-            // would swap every sprite in the game for the wrong art.
-            const record = { atlasKey: currentAtlasKey, frames: atlasData.frames };
+            // One record per atlas, not one slot shared by all of them. The
+            // Atlas Manager switches which atlas is being edited, and a single
+            // slot would mean a trip to game_ui silently threw away the
+            // game_asset art the runtime needs — the imported sprites would be
+            // gone from Play with nothing to say why.
+            const atlasKey = currentAtlasKey;
+            const frames = atlasData.frames;
             return new Promise((resolve) => {
                 try {
                     const cv = document.createElement('canvas');
@@ -826,8 +829,12 @@
                             if (!db) { resolve(false); return; }
                             try {
                                 const tx = db.transaction('assets', 'readwrite');
-                                tx.objectStore('assets').put(blob, 'atlasImage');
-                                tx.objectStore('assets').put(record, 'atlasFrames');
+                                const store = tx.objectStore('assets');
+                                // Legacy single-slot image the boss/attack
+                                // viewers already read — they follow whichever
+                                // atlas is open, so this keeps tracking it.
+                                store.put(blob, 'atlasImage');
+                                store.put({ atlasKey, frames, blob }, VIEWER_BRIDGE_ATLAS_PREFIX + atlasKey);
                                 tx.oncomplete = function () { resolve(true); };
                                 tx.onerror = function () { resolve(false); };
                             } catch (e2) { resolve(false); }
@@ -837,17 +844,24 @@
             });
         }
 
-        // Open the bridge with its 'assets' store guaranteed to exist. A plain
-        // open(name, 1) is not enough: another page on this origin can create
-        // the database first (any open() of a missing name creates it), and
-        // then version 1 already exists with no store, so onupgradeneeded never
-        // fires and every write throws NotFoundError forever. Reopen a version
-        // up to add the store when we find it missing.
+        const VIEWER_BRIDGE_ATLAS_PREFIX = 'atlas:';
+
+        // Open the bridge with its 'assets' store guaranteed to exist.
+        //
+        // Never pass a fixed version. Any open() of a name that does not exist
+        // creates it, so another page on this origin can leave an empty
+        // database behind; if we then asked for version 1 we would either skip
+        // the upgrade that adds the store (when it is already at 1) or be
+        // rejected outright with VersionError (when a previous recovery already
+        // moved it to 2). Opening version-less reads whatever is there, and the
+        // store gets added by an upgrade to current+1 only when it is missing.
         function openViewerBridge() {
             return new Promise((resolve) => {
                 let req;
-                try { req = indexedDB.open('editorViewerBridge', 1); }
+                try { req = indexedDB.open('editorViewerBridge'); }
                 catch (e) { resolve(null); return; }
+                // Fires with oldVersion 0 when the database is new — create the
+                // store here so the fresh case needs no second open.
                 req.onupgradeneeded = (e) => {
                     const db = e.target.result;
                     if (!db.objectStoreNames.contains('assets')) db.createObjectStore('assets');

--- a/level-editor.html
+++ b/level-editor.html
@@ -791,29 +791,84 @@
             try { sessionStorage.setItem('editorBossData', JSON.stringify(bossData)); } catch (e) {}
             storeAtlasForViewers();
         }
+        // Publish the working atlas for the other pages that render this game's
+        // art: the boss/attack viewers, and the Phaser runtime when you press
+        // Play. Play hands over a recipe of texture *names* through
+        // localStorage, so without the art here the runtime falls back to the
+        // on-disk game_asset and anything the editor added — an uploaded sprite,
+        // a Dezaemon import — resolves to frame 0.
+        //
+        // The frames go to IndexedDB alongside the image rather than relying on
+        // the sessionStorage copy below: a window.open'd tab only inherits a
+        // snapshot of sessionStorage, so that copy is a dead end for anything
+        // opened before the atlas changed. The sessionStorage write stays for
+        // the viewers that already read it. Returns a promise that settles once
+        // the bridge is durable, so callers can hand off without racing it.
         function storeAtlasForViewers() {
             // Store atlas frames JSON in sessionStorage
             if (atlasData && atlasData.frames) {
                 try { sessionStorage.setItem('editorAtlasFrames', JSON.stringify(atlasData)); } catch (e) {}
             }
-            // Store atlas image in IndexedDB (too large for sessionStorage)
-            if (atlasImage && atlasImage.complete && atlasImage.naturalWidth > 0) {
+            if (!atlasData || !atlasData.frames) return Promise.resolve(false);
+            if (!(atlasImage && atlasImage.complete && atlasImage.naturalWidth > 0)) return Promise.resolve(false);
+            // Snapshot the key with the frames: the editor can be pointed at
+            // game_ui, and dropping that atlas onto the runtime's game_asset
+            // would swap every sprite in the game for the wrong art.
+            const record = { atlasKey: currentAtlasKey, frames: atlasData.frames };
+            return new Promise((resolve) => {
                 try {
                     const cv = document.createElement('canvas');
                     cv.width = atlasImage.naturalWidth; cv.height = atlasImage.naturalHeight;
                     cv.getContext('2d').drawImage(atlasImage, 0, 0);
-                    cv.toBlob(function(blob) {
-                        if (!blob) return;
-                        const req = indexedDB.open('editorViewerBridge', 1);
-                        req.onupgradeneeded = function(e) { e.target.result.createObjectStore('assets'); };
-                        req.onsuccess = function(e) {
-                            const db = e.target.result;
-                            const tx = db.transaction('assets', 'readwrite');
-                            tx.objectStore('assets').put(blob, 'atlasImage');
-                        };
+                    cv.toBlob(function (blob) {
+                        if (!blob) { resolve(false); return; }
+                        openViewerBridge().then((db) => {
+                            if (!db) { resolve(false); return; }
+                            try {
+                                const tx = db.transaction('assets', 'readwrite');
+                                tx.objectStore('assets').put(blob, 'atlasImage');
+                                tx.objectStore('assets').put(record, 'atlasFrames');
+                                tx.oncomplete = function () { resolve(true); };
+                                tx.onerror = function () { resolve(false); };
+                            } catch (e2) { resolve(false); }
+                        });
                     }, 'image/png');
-                } catch (e) {}
-            }
+                } catch (e) { resolve(false); }
+            });
+        }
+
+        // Open the bridge with its 'assets' store guaranteed to exist. A plain
+        // open(name, 1) is not enough: another page on this origin can create
+        // the database first (any open() of a missing name creates it), and
+        // then version 1 already exists with no store, so onupgradeneeded never
+        // fires and every write throws NotFoundError forever. Reopen a version
+        // up to add the store when we find it missing.
+        function openViewerBridge() {
+            return new Promise((resolve) => {
+                let req;
+                try { req = indexedDB.open('editorViewerBridge', 1); }
+                catch (e) { resolve(null); return; }
+                req.onupgradeneeded = (e) => {
+                    const db = e.target.result;
+                    if (!db.objectStoreNames.contains('assets')) db.createObjectStore('assets');
+                };
+                req.onerror = () => resolve(null);
+                req.onsuccess = (e) => {
+                    const db = e.target.result;
+                    if (db.objectStoreNames.contains('assets')) { resolve(db); return; }
+                    const version = db.version + 1;
+                    db.close();
+                    let up;
+                    try { up = indexedDB.open('editorViewerBridge', version); }
+                    catch (e2) { resolve(null); return; }
+                    up.onupgradeneeded = (ev) => {
+                        const udb = ev.target.result;
+                        if (!udb.objectStoreNames.contains('assets')) udb.createObjectStore('assets');
+                    };
+                    up.onsuccess = (ev) => resolve(ev.target.result);
+                    up.onerror = () => resolve(null);
+                };
+            });
         }
         let pendingTextureUploads = {};  // textureName -> { key, canvas, w, h }
         let currentMissingSet = new Set(); // textures shown in the missing panel
@@ -2388,7 +2443,10 @@
                     extraSprites = [];
                     replacedFrames = {};
                     buildFrameThumbs();
-                    resolve(true);
+                    // Publish before resolving: the caller (an import) is the
+                    // last step before the user can press Play, and the runtime
+                    // reads this bridge for the art it just folded in.
+                    storeAtlasForViewers().then(() => resolve(true));
                 };
                 img.onerror = () => resolve(false);
                 img.src = result.canvas.toDataURL('image/png');
@@ -2511,7 +2569,7 @@
             return r;
         }
 
-        function playCurrentStage() {
+        async function playCurrentStage() {
             if (!gameData) { alert('Load directory first'); return; }
             if (!syncEnemyEditorForm(true)) return;
             const sid = getCurrentStageId();
@@ -2519,6 +2577,12 @@
                 localStorage.setItem(EDITOR_PLAY_RECIPE_KEY, JSON.stringify(buildRuntimeRecipe()));
                 localStorage.setItem(EDITOR_PLAY_STAGE_KEY, String(sid));
             } catch (e) { alert('Error: ' + e.message); return; }
+            // The recipe is only texture names — republish the art it points at
+            // before opening the game, so a frame edited since the last publish
+            // is the one that plays. Every mutation path already publishes, so
+            // this is normally a fast no-op rewrite; it settles well inside the
+            // window where a click still authorizes window.open.
+            await storeAtlasForViewers();
             window.open(`phaser-game.html?editorPlay=1&stage=${sid}`, '_blank');
         }
 

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -166,10 +166,11 @@ function getAllCustomAudioEntries() {
 // art, so without reading this the runtime only has the on-disk game_asset and
 // every imported deza*.gif resolves to game_asset's frame 0 (the player), which
 // is why an imported save used to play as an army of G clones.
+// Records are keyed per atlas ("atlas:game_asset", "atlas:game_ui"), so which
+// atlas the editor happens to have open does not decide what the game gets.
 var EDITOR_BRIDGE_DB_NAME = "editorViewerBridge";
 var EDITOR_BRIDGE_STORE = "assets";
-var EDITOR_BRIDGE_IMAGE_KEY = "atlasImage";
-var EDITOR_BRIDGE_FRAMES_KEY = "atlasFrames";
+var EDITOR_BRIDGE_GAME_ASSET_KEY = "atlas:game_asset";
 
 function readEditorAtlasBridge() {
     if (typeof indexedDB === "undefined") {
@@ -205,17 +206,14 @@ function readEditorAtlasBridge() {
             }
             try {
                 var tx = db.transaction(EDITOR_BRIDGE_STORE, "readonly");
-                var store = tx.objectStore(EDITOR_BRIDGE_STORE);
-                var imageReq = store.get(EDITOR_BRIDGE_IMAGE_KEY);
-                var framesReq = store.get(EDITOR_BRIDGE_FRAMES_KEY);
+                var recordReq = tx.objectStore(EDITOR_BRIDGE_STORE).get(EDITOR_BRIDGE_GAME_ASSET_KEY);
                 tx.oncomplete = function () {
-                    var record = framesReq.result;
-                    var blob = imageReq.result;
-                    if (!blob || !record || !record.frames) {
+                    var record = recordReq.result;
+                    if (!record || !record.frames || !record.blob) {
                         resolve(null);
                         return;
                     }
-                    resolve({ atlasKey: record.atlasKey || null, frames: record.frames, blob: blob });
+                    resolve({ frames: record.frames, blob: record.blob });
                 };
                 tx.onerror = function () { resolve(null); };
             } catch (error) {
@@ -526,7 +524,7 @@ export class BootScene extends Phaser.Scene {
             // editor's working atlas across before anything draws. Any failure
             // here is non-fatal: boot with the on-disk art rather than not at all.
             readEditorAtlasBridge().then(function (bridge) {
-                if (!bridge || (bridge.atlasKey && bridge.atlasKey !== "game_asset")) {
+                if (!bridge) {
                     return null;
                 }
                 return blobToImage(bridge.blob).then(function (img) {

--- a/src/phaser/BootScene.js
+++ b/src/phaser/BootScene.js
@@ -160,6 +160,136 @@ function getAllCustomAudioEntries() {
     });
 }
 
+// The level editor keeps its working atlas — stock frames plus anything added
+// by a sprite upload or a Dezaemon import — in this IndexedDB bridge, rewritten
+// on every atlas change. "Play" hands over a recipe through localStorage but no
+// art, so without reading this the runtime only has the on-disk game_asset and
+// every imported deza*.gif resolves to game_asset's frame 0 (the player), which
+// is why an imported save used to play as an army of G clones.
+var EDITOR_BRIDGE_DB_NAME = "editorViewerBridge";
+var EDITOR_BRIDGE_STORE = "assets";
+var EDITOR_BRIDGE_IMAGE_KEY = "atlasImage";
+var EDITOR_BRIDGE_FRAMES_KEY = "atlasFrames";
+
+function readEditorAtlasBridge() {
+    if (typeof indexedDB === "undefined") {
+        return Promise.resolve(null);
+    }
+    return new Promise(function (resolve) {
+        var req;
+        try {
+            // Open without a version so an existing bridge is read at whatever
+            // version the editor made it.
+            req = indexedDB.open(EDITOR_BRIDGE_DB_NAME);
+        } catch (error) {
+            resolve(null);
+            return;
+        }
+        // Opening a database that does not exist creates it. If that happens
+        // here — the editor has never run in this browser — the empty v1 we
+        // just made would stop the editor's own `open(name, 1)` from ever
+        // firing onupgradeneeded, so it could never create the store and the
+        // bridge would be dead for good. Throw our accidental creation away.
+        var created = false;
+        req.onupgradeneeded = function () { created = true; };
+        req.onerror = function () { resolve(null); };
+        req.onsuccess = function (e) {
+            var db = e.target.result;
+            if (created || !db.objectStoreNames.contains(EDITOR_BRIDGE_STORE)) {
+                try {
+                    db.close();
+                    if (created) indexedDB.deleteDatabase(EDITOR_BRIDGE_DB_NAME);
+                } catch (error) {}
+                resolve(null);
+                return;
+            }
+            try {
+                var tx = db.transaction(EDITOR_BRIDGE_STORE, "readonly");
+                var store = tx.objectStore(EDITOR_BRIDGE_STORE);
+                var imageReq = store.get(EDITOR_BRIDGE_IMAGE_KEY);
+                var framesReq = store.get(EDITOR_BRIDGE_FRAMES_KEY);
+                tx.oncomplete = function () {
+                    var record = framesReq.result;
+                    var blob = imageReq.result;
+                    if (!blob || !record || !record.frames) {
+                        resolve(null);
+                        return;
+                    }
+                    resolve({ atlasKey: record.atlasKey || null, frames: record.frames, blob: blob });
+                };
+                tx.onerror = function () { resolve(null); };
+            } catch (error) {
+                resolve(null);
+            }
+        };
+    });
+}
+
+function blobToImage(blob) {
+    return new Promise(function (resolve) {
+        var url = URL.createObjectURL(blob);
+        var img = new Image();
+        img.onload = function () { URL.revokeObjectURL(url); resolve(img); };
+        img.onerror = function () { URL.revokeObjectURL(url); resolve(null); };
+        img.src = url;
+    });
+}
+
+// Stack `image` under the loaded game_asset texture and rebuild the frame map so
+// both sets resolve from one texture. Incoming frames win on a name collision —
+// they are the customization — and .gif/.png spellings of the same name are
+// treated as the same frame, since the editor and Firebase disagree on suffix.
+//
+// Merging rather than replacing matters: the incoming atlas may be missing
+// frames the runtime needs (player00.gif and friends), and those keep resolving
+// from the local copy instead of disappearing.
+function mergeAtlasIntoGameAsset(scene, image, frames) {
+    var localAtlas = scene.textures.get("game_asset");
+    var localSource = localAtlas && localAtlas.source && localAtlas.source[0] ? localAtlas.source[0].image : null;
+    var localFrames = localAtlas ? localAtlas.frames : {};
+    if (!localSource) {
+        return false;
+    }
+
+    var localW = localSource.width;
+    var localH = localSource.height;
+    var mergedCanvas = document.createElement("canvas");
+    mergedCanvas.width = Math.max(localW, image.width);
+    mergedCanvas.height = localH + image.height;
+    var mctx = mergedCanvas.getContext("2d");
+    mctx.drawImage(localSource, 0, 0);
+    mctx.drawImage(image, 0, localH);
+
+    var mergedFrameMap = {};
+    for (var lk in localFrames) {
+        if (lk === "__BASE") continue;
+        var lf = localFrames[lk];
+        if (lf && lf.cutX !== undefined) {
+            mergedFrameMap[lk] = { frame: { x: lf.cutX, y: lf.cutY, w: lf.cutWidth, h: lf.cutHeight } };
+        }
+    }
+    for (var fname in frames) {
+        var decodedName = fname.replace(/․/g, ".");
+        var fd = frames[fname];
+        if (!fd || !fd.frame) continue;
+        var frameData = { frame: { x: fd.frame.x, y: fd.frame.y + localH, w: fd.frame.w, h: fd.frame.h } };
+        mergedFrameMap[decodedName] = frameData;
+        var altName = null;
+        if (decodedName.endsWith(".png")) {
+            altName = decodedName.slice(0, -4) + ".gif";
+        } else if (decodedName.endsWith(".gif")) {
+            altName = decodedName.slice(0, -4) + ".png";
+        }
+        if (altName && mergedFrameMap[altName]) {
+            mergedFrameMap[altName] = frameData;
+        }
+    }
+
+    scene.textures.remove("game_asset");
+    scene.textures.addAtlas("game_asset", mergedCanvas, { frames: mergedFrameMap });
+    return true;
+}
+
 function primeGameStateForStage(recipe, stageId) {
     if (recipe && recipe.playerData) {
         gameState.spDamage = recipe.playerData.spDamage;
@@ -392,7 +522,22 @@ export class BootScene extends Phaser.Scene {
         // Editor play requests use localStorage recipe, skip Firebase
         var editorPlay = readEditorPlayRequest();
         if (editorPlay) {
-            this._finishBoot();
+            // ...but the recipe carries texture *names* only, so pull the
+            // editor's working atlas across before anything draws. Any failure
+            // here is non-fatal: boot with the on-disk art rather than not at all.
+            readEditorAtlasBridge().then(function (bridge) {
+                if (!bridge || (bridge.atlasKey && bridge.atlasKey !== "game_asset")) {
+                    return null;
+                }
+                return blobToImage(bridge.blob).then(function (img) {
+                    if (!img) return null;
+                    return mergeAtlasIntoGameAsset(self, img, bridge.frames);
+                });
+            }).catch(function (err) {
+                console.warn("Editor atlas bridge unavailable, using on-disk art:", err);
+            }).then(function () {
+                self._finishBoot();
+            });
             return;
         }
 
@@ -634,57 +779,7 @@ export class BootScene extends Phaser.Scene {
                 var fbImg = new Image();
                 fbImg.onload = function () {
                     try {
-                        // Get the local atlas source image
-                        var localAtlas = self.textures.get("game_asset");
-                        var localSource = localAtlas && localAtlas.source && localAtlas.source[0] ? localAtlas.source[0].image : null;
-                        var localFrames = localAtlas ? localAtlas.frames : {};
-                        if (!localSource) { finishLevelLoad(); return; }
-
-                        // Create merged canvas: stack local image on top, Firebase image below
-                        var mergedCanvas = document.createElement("canvas");
-                        var localW = localSource.width, localH = localSource.height;
-                        var fbW = fbImg.width, fbH = fbImg.height;
-                        mergedCanvas.width = Math.max(localW, fbW);
-                        mergedCanvas.height = localH + fbH;
-                        var mctx = mergedCanvas.getContext("2d");
-                        mctx.drawImage(localSource, 0, 0);
-                        mctx.drawImage(fbImg, 0, localH);
-
-                        // Build merged frame map: local frames stay as-is, Firebase frames offset by localH
-                        var mergedFrameMap = {};
-                        for (var lk in localFrames) {
-                            if (lk === "__BASE") continue;
-                            var lf = localFrames[lk];
-                            if (lf && lf.cutX !== undefined) {
-                                mergedFrameMap[lk] = { frame: { x: lf.cutX, y: lf.cutY, w: lf.cutWidth, h: lf.cutHeight } };
-                            }
-                        }
-                        // Add Firebase frames with Y offset
-                        for (var fname in data.atlasFrames) {
-                            var decodedName = fname.replace(/\u2024/g, ".");
-                            var fd = data.atlasFrames[fname];
-                            if (fd && fd.frame) {
-                                var frameData = {
-                                    frame: { x: fd.frame.x, y: fd.frame.y + localH, w: fd.frame.w, h: fd.frame.h }
-                                };
-                                mergedFrameMap[decodedName] = frameData;
-                                // Firebase frames stored as .png should also overwrite matching .gif
-                                // local frames (and vice versa) so animations find the replacements
-                                var altName = null;
-                                if (decodedName.endsWith(".png")) {
-                                    altName = decodedName.slice(0, -4) + ".gif";
-                                } else if (decodedName.endsWith(".gif")) {
-                                    altName = decodedName.slice(0, -4) + ".png";
-                                }
-                                if (altName && mergedFrameMap[altName]) {
-                                    mergedFrameMap[altName] = frameData;
-                                }
-                            }
-                        }
-
-                        // Replace game_asset with merged atlas
-                        self.textures.remove("game_asset");
-                        self.textures.addAtlas("game_asset", mergedCanvas, { frames: mergedFrameMap });
+                        mergeAtlasIntoGameAsset(self, fbImg, data.atlasFrames);
                     } catch (atlasErr) {
                         console.warn("Failed to merge Firebase atlas:", atlasErr);
                     }

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -20,14 +20,15 @@ module.exports = defineConfig({
     projects: [
         {
             name: "editor",
-            testIgnore: /editor-play-smoke/,
+            testIgnore: /editor-play-smoke|sav-import-play/,
             use: { browserName: "chromium" },
         },
         {
-            // The Phaser boot smoke is the slow/flaky one (7MB asset load) —
-            // isolated so its retries never slow the editor specs.
+            // Specs that boot Phaser for real are the slow/flaky ones (7MB
+            // asset load) — isolated so their retries never slow the editor
+            // specs.
             name: "game-smoke",
-            testMatch: /editor-play-smoke/,
+            testMatch: /editor-play-smoke|sav-import-play/,
             timeout: 240_000,
             workers: 1,
             use: { browserName: "chromium" },

--- a/tests/e2e/specs/sav-import-play.spec.js
+++ b/tests/e2e/specs/sav-import-play.spec.js
@@ -84,3 +84,57 @@ test("an imported save plays with its own enemy art, not game_asset frame 0", as
 
     expect(missingFrameWarnings).toEqual([]);
 });
+
+// The Atlas Manager switches which atlas the editor is editing, and publishing
+// republishes whatever is open. With one shared bridge slot, a look at game_ui
+// after an import would overwrite the game_asset art the runtime needs and the
+// imported sprites would vanish from Play again — so records are per atlas.
+test("switching the editor to another atlas does not strip the imported art from Play", async ({ page, context }) => {
+    page.on("dialog", (d) => d.accept());
+
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => !!window.Dezaemon)).toBe(true);
+    await expect.poll(() => page.evaluate(() => !!(atlasData && atlasData.frames))).toBe(true);
+
+    await page.setInputFiles("#deza-file-input", RAMSIE);
+    await page.locator("#deza-slot-list > div").first().click();
+    await page.locator("#deza-import-btn").click();
+    await expect(page.locator("#dezaemon-import-modal")).toBeHidden();
+
+    const wanted = await page.evaluate(() =>
+        Object.values(gameData.enemyData).map((e) => (e.texture || [])[0]).filter((t) => /^deza/.test(t)));
+    expect(wanted.length).toBeGreaterThan(10);
+
+    await page.evaluate(() => {
+        localStorage.setItem("__editorPhaserRecipe__", JSON.stringify(buildRuntimeRecipe()));
+        localStorage.setItem("__editorPhaserStageId__", "0");
+    });
+
+    // Wander off to another atlas, exactly as the Atlas Manager dropdown does,
+    // then press Play (which republishes whatever is now open).
+    await page.evaluate(() => switchAtlas("game_ui"));
+    await expect.poll(() => page.evaluate(() => currentAtlasKey)).toBe("game_ui");
+    await page.evaluate(() => storeAtlasForViewers());
+
+    const gamePage = await context.newPage();
+    await gamePage.goto("/phaser-game.html?editorPlay=1&stage=0&lowmode=1");
+    await expect.poll(() => gamePage.evaluate(() => {
+        const g = window.__PHASER_4_GAME__;
+        if (!g) return "booting";
+        const now = g.loop ? g.loop.time : 0;
+        if (window.__lastLoopTime === now && g.loop) {
+            for (let i = 0; i < 20; i++) g.loop.step(performance.now() + i * 16.7);
+        }
+        window.__lastLoopTime = now;
+        const active = g.scene.getScenes(true).map((s) => s.scene.key);
+        return active.includes("PhaserGameScene") ? "PhaserGameScene" : active.join(",") || "none";
+    }), { timeout: 210_000, intervals: [1000] }).toBe("PhaserGameScene");
+
+    const resolved = await gamePage.evaluate((keys) => {
+        const s = window.__PHASER_4_GAME__.scene.getScene("PhaserGameScene");
+        const frames = s.textures.get("game_asset").frames;
+        return { missing: keys.filter((k) => !frames[k]), playerPresent: !!frames["player00.gif"] };
+    }, wanted);
+    expect(resolved.missing).toEqual([]);
+    expect(resolved.playerPresent).toBe(true);
+});

--- a/tests/e2e/specs/sav-import-play.spec.js
+++ b/tests/e2e/specs/sav-import-play.spec.js
@@ -1,0 +1,86 @@
+"use strict";
+const path = require("path");
+const { test, expect } = require("@playwright/test");
+
+const RAMSIE = path.resolve(__dirname, "..", "..", "..", "tools", "dezaemon-import", "fixtures", "ramsie.sav");
+
+// The editor's Play handoff writes a recipe of texture *names* to localStorage.
+// Without the atlas bridge the runtime only has the on-disk game_asset, every
+// imported deza*.gif misses, and Phaser falls back to frame 0 — which is the
+// player — so an imported save played as an army of identical G sprites.
+test("an imported save plays with its own enemy art, not game_asset frame 0", async ({ page, context }) => {
+    page.on("dialog", (d) => d.accept());
+
+    await page.goto("/level-editor.html");
+    await expect.poll(() => page.evaluate(() => !!window.Dezaemon)).toBe(true);
+    await expect.poll(() => page.evaluate(() => !!(atlasData && atlasData.frames))).toBe(true);
+
+    await page.setInputFiles("#deza-file-input", RAMSIE);
+    await page.locator("#deza-slot-list > div").first().click();
+    await page.locator("#deza-import-btn").click();
+    await expect(page.locator("#dezaemon-import-modal")).toBeHidden();
+
+    // The imported enemies must reference the save's own frames, or the rest of
+    // this test would pass for the wrong reason.
+    const wanted = await page.evaluate(() =>
+        Object.values(gameData.enemyData).map((e) => (e.texture || [])[0]).filter((t) => /^deza/.test(t)));
+    expect(wanted.length).toBeGreaterThan(10);
+
+    const gamePage = await context.newPage();
+    const missingFrameWarnings = [];
+    gamePage.on("console", (m) => {
+        const t = m.text();
+        if (t.includes("has no frame")) missingFrameWarnings.push(t);
+    });
+
+    await page.evaluate(() => {
+        localStorage.setItem("__editorPhaserRecipe__", JSON.stringify(buildRuntimeRecipe()));
+        localStorage.setItem("__editorPhaserStageId__", "0");
+    });
+    await page.evaluate(() => storeAtlasForViewers());
+
+    await gamePage.goto("/phaser-game.html?editorPlay=1&stage=0&lowmode=1");
+    await expect.poll(() => gamePage.evaluate(() => {
+        const g = window.__PHASER_4_GAME__;
+        if (!g) return "booting";
+        const now = g.loop ? g.loop.time : 0;
+        if (window.__lastLoopTime === now && g.loop) {
+            for (let i = 0; i < 20; i++) g.loop.step(performance.now() + i * 16.7);
+        }
+        window.__lastLoopTime = now;
+        const active = g.scene.getScenes(true).map((s) => s.scene.key);
+        return active.includes("PhaserGameScene") ? "PhaserGameScene" : active.join(",") || "none";
+    }), { timeout: 210_000, intervals: [1000] }).toBe("PhaserGameScene");
+
+    // Every frame the imported enemies ask for resolves in the runtime atlas...
+    const resolved = await gamePage.evaluate((keys) => {
+        const s = window.__PHASER_4_GAME__.scene.getScene("PhaserGameScene");
+        const frames = s.textures.get("game_asset").frames;
+        return {
+            missing: keys.filter((k) => !frames[k]),
+            playerPresent: !!frames["player00.gif"],
+            shotPresent: !!frames["shot00.gif"],
+        };
+    }, wanted);
+    expect(resolved.missing).toEqual([]);
+    // ...and folding the editor atlas in must not cost the stock art.
+    expect(resolved.playerPresent).toBe(true);
+    expect(resolved.shotPresent).toBe(true);
+
+    // Run the stage far enough to spawn, then check the enemies on screen are
+    // drawn from the save's frames rather than all collapsing onto one.
+    const drawn = await gamePage.evaluate(async () => {
+        const g = window.__PHASER_4_GAME__;
+        const s = g.scene.getScene("PhaserGameScene");
+        for (let i = 0; i < 900; i++) g.loop.step(performance.now() + 3000 + i * 16.7);
+        await new Promise((r) => setTimeout(r, 1500));
+        for (let i = 0; i < 900; i++) g.loop.step(performance.now() + 20000 + i * 16.7);
+        const frames = (s.enemies || []).map((e) => e.frame.name);
+        return { count: frames.length, distinct: [...new Set(frames)], playerFrame: s.playerSprite.frame.name };
+    });
+    expect(drawn.count).toBeGreaterThan(0);
+    for (const f of drawn.distinct) expect(f).toMatch(/^deza/);
+    expect(drawn.playerFrame).toMatch(/^player0\d\.gif$/);
+
+    expect(missingFrameWarnings).toEqual([]);
+});


### PR DESCRIPTION
Follow-up to #270, fixing the gap noted there as out of scope.

Play hands the runtime a recipe through `localStorage`, but a recipe is only texture *names* — the art stayed behind in the editor. Anything the editor added rather than loaded from disk (a Dezaemon import's `deza*.gif`, an uploaded sprite) missed in the runtime's `game_asset`, so Phaser fell back to the texture's frame 0. Frame 0 is the player, which is why an imported save played as an army of identical G sprites.

## Changes

**`level-editor.html`**
- `storeAtlasForViewers()` now writes the frame map into the existing `editorViewerBridge` IndexedDB store next to the image, and returns a promise so callers can hand off without racing the write. The frames can't ride on `sessionStorage` — a `window.open`'d tab only inherits a snapshot taken at open time — but the existing `sessionStorage` write stays for the viewers already reading it.
- Records are keyed **per atlas** (`atlas:game_asset`, `atlas:game_ui`). The Atlas Manager switches which atlas is being edited, and a single shared slot would mean a look at `game_ui` after an import silently discarded the `game_asset` art the runtime needs. The legacy single-slot `atlasImage` the boss/attack viewers read is still maintained and still follows the open atlas.
- `mergeExtraSpritesIntoAtlas()` publishes before resolving, so an import's merged atlas is on the bridge before Play is reachable; `playCurrentStage()` republishes before opening the window.

**`src/phaser/BootScene.js`**
- The Firebase level path's atlas merge is extracted to `mergeAtlasIntoGameAsset()` and shared. The `editorPlay` path now reads the `atlas:game_asset` record and merges through it before `_finishBoot()`; any failure falls through to the on-disk art rather than blocking boot.
- Merging rather than replacing means a frame the bridge lacks still resolves from the local atlas.

**Store-creation race, guarded on both sides.** Any `open()` of a missing database creates it, so a game page opening the bridge first would leave an empty v1 with no object store. The reader throws away a database it accidentally created. The writer never pins a version: it opens version-less (which creates the store in `onupgradeneeded` when the database is new) and upgrades to `db.version + 1` only when the store is genuinely missing — pinning version 1 would be rejected with `VersionError` once a recovery had already moved it to 2, silently dropping every later publish.

## Testing

- `npm run test:unit` — 69 pass, 1 pre-existing skip.
- `npm run test:e2e` — 16 pass. New spec `sav-import-play.spec.js` covers two flows:
  - Import the Ramsie fixture and play it: every frame the imported enemies reference resolves in the runtime atlas, the on-screen enemies draw *distinct* `deza*` frames rather than collapsing onto one, the stock player/shot frames survive the merge, and no `has no frame` warning is logged. Fails without the BootScene change (27 unresolvable frames).
  - Import, switch the editor to `game_ui`, publish, then play: the imported art still reaches the runtime. Pinning both records to one shared key reproduces the old failure (27 unresolvable frames).
- The spec boots Phaser for real, so it's in the `game-smoke` project with the other slow one rather than the 30s `editor` project.
- Confirmed visually: the imported save renders Ramsie's own enemy art and the Evil Invaders ship, instead of the wall of G sprites.